### PR TITLE
Implement structured lifecycle logging for webhook listener/worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/docs/webhook-listener.md
+++ b/docs/webhook-listener.md
@@ -92,6 +92,7 @@ Use the same value in:
 - `GITHUB_ORG`
 - `GITHUB_PROJECT_NAME`
 - `WEBHOOK_PUBSUB_TOPIC` (`projects/<project>/topics/<topic>`)
+- `ACE_LOG_FORMAT=json` (required on Cloud Run)
 
 Optional (notifications):
 
@@ -194,3 +195,33 @@ Recommended Cloud Run concurrency:
 
 - Listener: high concurrency (e.g. `40` or default) because work is short-lived enqueue.
 - Worker: `1` to process one issue/event at a time per instance.
+
+## Cloud Run Logging Requirement
+
+Cloud Run listener/worker deployments must set `ACE_LOG_FORMAT=json` so lifecycle logs remain queryable.
+
+Listener update example:
+
+```bash
+gcloud run services update appforge-webhooks-listener \
+  --region us-central1 \
+  --set-env-vars WEBHOOK_SERVICE_ROLE=listener,ACE_LOG_FORMAT=json
+```
+
+Worker update example:
+
+```bash
+gcloud run services update appforge-webhooks-worker \
+  --region us-central1 \
+  --set-env-vars WEBHOOK_SERVICE_ROLE=worker,ACE_LOG_FORMAT=json
+```
+
+Validate env vars:
+
+```bash
+gcloud run services describe appforge-webhooks-listener \
+  --region us-central1 \
+  --format="value(spec.template.spec.containers[0].env)"
+```
+
+The webhook app startup now fails on Cloud Run if `ACE_LOG_FORMAT` is not `json`.

--- a/src/ace/agents/cli_agent.py
+++ b/src/ace/agents/cli_agent.py
@@ -13,12 +13,12 @@ from typing import Any
 
 import structlog
 
+from ace.config.secrets import resolve_claude_api_key, resolve_github_token, resolve_openai_api_key
 from ace.config.settings import get_settings
-from ace.config.secrets import resolve_github_token, resolve_openai_api_key, resolve_claude_api_key
 from ace.notifications.slack_client import SlackMessage, SlackNotifier
 
-from .types import AgentResult, AgentStatus
 from .mcp_config import ensure_mcp_config
+from .types import AgentResult, AgentStatus
 
 logger = structlog.get_logger(__name__)
 
@@ -108,14 +108,10 @@ class CliAgent:
 
             summary = str(marker.get("summary") or "").strip()
             files_changed = (
-                marker.get("files_changed")
-                if isinstance(marker.get("files_changed"), list)
-                else []
+                marker.get("files_changed") if isinstance(marker.get("files_changed"), list) else []
             )
             commands_run = (
-                marker.get("commands_run")
-                if isinstance(marker.get("commands_run"), list)
-                else []
+                marker.get("commands_run") if isinstance(marker.get("commands_run"), list) else []
             )
             if not commands_run:
                 commands_run = [command_display]
@@ -143,9 +139,7 @@ class CliAgent:
                 stderr = stderr_text.strip()
                 stdout = stdout_text.strip()
                 details = stderr or stdout or f"exit code {return_code}"
-                raise RuntimeError(
-                    f"❌ ERROR: cli_process_failed: {details}"
-                )
+                raise RuntimeError(f"❌ ERROR: cli_process_failed: {details}")
 
             return AgentResult(
                 status=AgentStatus.SUCCESS,
@@ -259,7 +253,7 @@ class CliAgent:
         model_value = self.model or ""
         display = template.replace("{model}", model_value).replace("{prompt}", "<prompt>")
 
-        # Quote the prompt so it is passed as a single positional argument even if it contains spaces.
+        # Quote prompt so shell parsing keeps it as one positional argument.
         formatted = template.replace("{model}", model_value)
         if "{prompt}" in formatted:
             formatted = formatted.replace("{prompt}", shlex.quote(prompt))
@@ -326,9 +320,10 @@ class CliAgent:
         started_at = time.monotonic()
         terminated_on_done = False
 
-        with tempfile.TemporaryFile(mode="w+b") as stdout_capture, tempfile.TemporaryFile(
-            mode="w+b"
-        ) as stderr_capture:
+        with (
+            tempfile.TemporaryFile(mode="w+b") as stdout_capture,
+            tempfile.TemporaryFile(mode="w+b") as stderr_capture,
+        ):
             proc: subprocess.Popen[bytes] = subprocess.Popen(
                 command,
                 cwd=str(workdir),
@@ -352,7 +347,10 @@ class CliAgent:
                     if proc.poll() is not None:
                         break
 
-                    if timeout_seconds is not None and (time.monotonic() - started_at) >= timeout_seconds:
+                    if (
+                        timeout_seconds is not None
+                        and (time.monotonic() - started_at) >= timeout_seconds
+                    ):
                         self._terminate_process(proc)
                         raise subprocess.TimeoutExpired(command, timeout_seconds)
 

--- a/src/ace/agents/llm_client.py
+++ b/src/ace/agents/llm_client.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import structlog
 import httpx
+import structlog
 
 logger = structlog.get_logger(__name__)
 
@@ -19,8 +19,8 @@ class _LangSmithTracer:
         self._api_key = ""
 
         try:
-            from ace.config.settings import get_settings
             from ace.config.secrets import resolve_langsmith_api_key
+            from ace.config.settings import get_settings
 
             settings = get_settings()
             api_key = resolve_langsmith_api_key(settings)

--- a/src/ace/agents/manager_agent.py
+++ b/src/ace/agents/manager_agent.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Iterable, Any
+from typing import Any, Iterable
 
 import structlog
 
 from ace.agents.llm_client import call_openai
-from ace.config.secrets import resolve_github_token
-from ace.config.secrets import resolve_openai_api_key
+from ace.config.secrets import resolve_github_token, resolve_openai_api_key
 from ace.config.settings import get_settings
 from ace.github.api_client import GitHubAPIClient
-from ace.github.issue_queue import Issue
-from ace.github.issue_queue import IssueQueue
+from ace.github.issue_queue import Issue, IssueQueue
 from ace.github.projects_v2 import ProjectsV2Client
 
 logger = structlog.get_logger(__name__)
@@ -32,8 +30,7 @@ class ManagerAgent:
         self.skill_text = self._load_skill_text()
         self.tool_loop_enabled = self.settings.manager_agent_tool_loop_enabled
         self.tool_loop_max_steps = (
-            self.settings.manager_agent_tool_loop_max_steps
-            or _DEFAULT_TOOL_LOOP_MAX_STEPS
+            self.settings.manager_agent_tool_loop_max_steps or _DEFAULT_TOOL_LOOP_MAX_STEPS
         )
         self._project_id: str | None = None
         github_token = resolve_github_token(self.settings)
@@ -211,8 +208,8 @@ class ManagerAgent:
             "- get_project_status {number, repo_owner, repo_name}\n"
             "\n"
             "Tool response format: JSON object with fields {tool, args, result}.\n"
-            "Tool call format: {\"action\":\"tool\",\"tool\":\"<name>\",\"args\":{...}}.\n"
-            "Done format: {\"action\":\"done\",\"selected\":[1,2],\"rationale\":\"...\"}.\n"
+            'Tool call format: {"action":"tool","tool":"<name>","args":{...}}.\n'
+            'Done format: {"action":"done","selected":[1,2],"rationale":"..."}.\n'
             "Return ONLY a JSON object or JSON array.\n"
         )
         base_prompt = (
@@ -346,7 +343,7 @@ def _safe_parse_int_list(raw: str) -> list[int]:
         return []
     values = []
     for part in inner.split(","):
-        part = part.strip().strip("\"")
+        part = part.strip().strip('"')
         if not part:
             continue
         try:

--- a/src/ace/agents/mcp_config.py
+++ b/src/ace/agents/mcp_config.py
@@ -36,9 +36,7 @@ def ensure_mcp_config(
         logger.info("mcp_config_written_github", path=str(config_path))
         if include_appforge_server:
             appforge_payload = _appforge_http_config(settings, appforge_allowlist)
-            _write_mcp_config(
-                config_path, appforge_payload, settings.appforge_mcp_server_name
-            )
+            _write_mcp_config(config_path, appforge_payload, settings.appforge_mcp_server_name)
             logger.info("mcp_config_written_appforge", path=str(config_path))
         _ensure_git_exclude(workdir, settings.mcp_config_filename)
         return
@@ -123,9 +121,9 @@ def _write_codex_server(
     allowed_tools: list[str] | None = None,
 ) -> None:
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    block = f"[mcp_servers.{server_name}]\n" f"url = \"{url}\"\n"
+    block = f'[mcp_servers.{server_name}]\nurl = "{url}"\n'
     if token_env_var:
-        block += f"bearer_token_env_var = \"{token_env_var}\"\n"
+        block += f'bearer_token_env_var = "{token_env_var}"\n'
     if allowed_tools:
         tools_literal = json.dumps(allowed_tools)
         block += f"allowed_tools = {tools_literal}\n"

--- a/src/ace/config/secrets.py
+++ b/src/ace/config/secrets.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import structlog
 from pathlib import Path
 
+import structlog
 from google.cloud import secretmanager
 from google.oauth2 import service_account
 
@@ -54,9 +54,7 @@ def _should_use_secret_manager(settings: Settings, secret_name: str) -> bool:
 
 def _validate_backend(settings: Settings) -> None:
     if settings.secrets_backend not in ("secret-manager", "env"):
-        raise ValueError(
-            f"❌ ERROR: Unsupported secrets backend: {settings.secrets_backend}"
-        )
+        raise ValueError(f"❌ ERROR: Unsupported secrets backend: {settings.secrets_backend}")
 
 
 def resolve_github_token(settings: Settings) -> str:

--- a/src/ace/config/settings.py
+++ b/src/ace/config/settings.py
@@ -69,7 +69,10 @@ class Settings(BaseSettings):
     # CLI agent commands
     codex_cli_command: str = os.getenv(
         "CODEX_CLI_COMMAND",
-        "codex --ask-for-approval never --full-auto --sandbox danger-full-access --model {model} {prompt}",
+        (
+            "codex --ask-for-approval never --full-auto "
+            "--sandbox danger-full-access --model {model} {prompt}"
+        ),
     )
     claude_cli_command: str = os.getenv(
         "CLAUDE_CLI_COMMAND",
@@ -146,7 +149,6 @@ class Settings(BaseSettings):
     # Slack notifications (bot)
     slack_bot_token: str = os.getenv("SLACK_BOT_TOKEN", os.getenv("SLACKBOT_TOKEN", ""))
     slack_channel_id: str = os.getenv("SLACK_CHANNEL_ID", "")
-
 
     class Config:
         env_file = ".env"

--- a/src/ace/github/issue_queue.py
+++ b/src/ace/github/issue_queue.py
@@ -98,10 +98,7 @@ class IssueQueue:
 
     async def list_open_prs_with_comments(self, org: str, label: str | None = None) -> list[Issue]:
         """List open PRs with comments (org-wide search)."""
-        query = (
-            f"org:{org} is:pr is:open comments:>0 "
-            '-label:"agent:comments-addressed"'
-        )
+        query = f'org:{org} is:pr is:open comments:>0 -label:"agent:comments-addressed"'
         if label:
             query += f' label:"{label}"'
         logger.info("listing_prs_with_comments", org=org, label=label)

--- a/src/ace/github/status_manager.py
+++ b/src/ace/github/status_manager.py
@@ -112,7 +112,9 @@ class StatusManager:
         blocked_comment = "**BLOCKED - Agent Needs Input**\n\n"
         for i, question in enumerate(questions, 1):
             blocked_comment += f"{i}. {question}\n"
-        blocked_comment += "\nPlease reply with your answers and re-add the `agent` label when ready to resume."
+        blocked_comment += (
+            "\nPlease reply with your answers and re-add the `agent` label when ready to resume."
+        )
 
         await self.issue_queue.remove_labels(
             issue_number,

--- a/src/ace/notifications/slack_client.py
+++ b/src/ace/notifications/slack_client.py
@@ -59,13 +59,9 @@ class SlackNotifier:
             data = {}
 
         if response.status_code >= 400:
-            raise ValueError(
-                f"❌ ERROR: Slack API error {response.status_code}: {response.text}"
-            )
+            raise ValueError(f"❌ ERROR: Slack API error {response.status_code}: {response.text}")
         if not data.get("ok"):
-            raise ValueError(
-                f"❌ ERROR: Slack API error: {data.get('error', 'unknown')}"
-            )
+            raise ValueError(f"❌ ERROR: Slack API error: {data.get('error', 'unknown')}")
 
     async def safe_post(self, message: SlackMessage) -> None:
         try:
@@ -103,9 +99,7 @@ def format_webhook_message(
     return SlackMessage(text=" | ".join(lines))
 
 
-def format_error_message(
-    event: str | None, delivery: str | None, exc: Exception
-) -> SlackMessage:
+def format_error_message(event: str | None, delivery: str | None, exc: Exception) -> SlackMessage:
     return SlackMessage(
         text=(
             "Webhook error | "

--- a/src/ace/orchestration/graph.py
+++ b/src/ace/orchestration/graph.py
@@ -18,12 +18,12 @@ from ace.agents.model_selector import ModelSelector
 from ace.agents.types import AgentResult, AgentStatus
 from ace.config.secrets import resolve_github_token, resolve_openai_api_key
 from ace.config.settings import get_settings
-from ace.notifications.slack_client import SlackNotifier, format_completion_message
 from ace.github.api_client import GitHubAPIClient
 from ace.github.issue_queue import IssueQueue
 from ace.github.projects_v2 import ProjectsV2Client
 from ace.github.status_manager import StatusManager
 from ace.logging_utils import log_key_event
+from ace.notifications.slack_client import SlackNotifier, format_completion_message
 from ace.orchestration.state import WorkerState
 from ace.workspaces.git_ops import GitOps
 from ace.workspaces.tmux_ops import TmuxOps
@@ -122,8 +122,11 @@ class InstructionBuilder:
 You are an instruction agent. Write detailed, step-by-step *programmatic* coding instructions
 for the issue below. Output Markdown only. Do not include UI/manual steps.
 Assume the repository is available; do not claim you cannot access files.
-Do not refuse or apologize; if information is missing, make reasonable assumptions and proceed with best-effort coding steps.
-If schema changes are needed, generate a timestamped Supabase migration (e.g., supabase/migrations/<YYYYMMDDHHMMSS>__desc.sql) using the current system time; do not place schema DDL in docs.
+Do not refuse or apologize; if information is missing, make reasonable assumptions
+and proceed with best-effort coding steps.
+If schema changes are needed, generate a timestamped Supabase migration
+(e.g., supabase/migrations/<YYYYMMDDHHMMSS>__desc.sql) using the current system
+time; do not place schema DDL in docs.
 
 Issue Title: {issue.title}
 Issue Body:
@@ -138,7 +141,8 @@ Include:
         completion = """
 
 When finished:
-- Create a file ACE_TASK_DONE.json in the repo root with fields: task_id (use "task-1"), summary, files_changed (array), commands_run (array).
+- Create a file ACE_TASK_DONE.json in the repo root with fields: task_id
+  (use "task-1"), summary, files_changed (array), commands_run (array).
 - Exit the session only after writing this file.
 """
         return body + completion

--- a/src/ace/runners/agent_pool.py
+++ b/src/ace/runners/agent_pool.py
@@ -533,7 +533,7 @@ class AgentPool:
             raise ValueError(error_message) from e
 
     async def _fetch_ready_issues_via_mcp(self) -> list[Issue]:
-        """Fetch ready issues via appforge MCP server (already filtered by status/label/blockers)."""
+        """Fetch ready issues from appforge MCP (pre-filtered by status/label/blockers)."""
         url = self.settings.appforge_mcp_url.rstrip("/")
         if not url.endswith("/mcp"):
             url = f"{url}/mcp"
@@ -830,7 +830,11 @@ class AgentPool:
         Returns:
             Summary of processing results
         """
-        repo = f"{issue.repo_owner}/{issue.repo_name}" if issue.repo_owner and issue.repo_name else None
+        repo = (
+            f"{issue.repo_owner}/{issue.repo_name}"
+            if issue.repo_owner and issue.repo_name
+            else None
+        )
         logger.info(
             "process_single_issue_starting",
             issue=issue.number,

--- a/src/ace/webhooks/app.py
+++ b/src/ace/webhooks/app.py
@@ -90,20 +90,14 @@ def _get_handler() -> WebhookHandler:
 
 def _verify_signature(secret: str, body: bytes, signature: str | None) -> None:
     if not secret:
-        raise HTTPException(
-            status_code=500, detail="❌ ERROR: GITHUB_WEBHOOK_SECRET not set"
-        )
+        raise HTTPException(status_code=500, detail="❌ ERROR: GITHUB_WEBHOOK_SECRET not set")
     if not signature:
-        raise HTTPException(
-            status_code=401, detail="❌ ERROR: Missing webhook signature"
-        )
+        raise HTTPException(status_code=401, detail="❌ ERROR: Missing webhook signature")
 
     mac = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256)
     expected = f"sha256={mac.hexdigest()}"
     if not hmac.compare_digest(expected, signature):
-        raise HTTPException(
-            status_code=401, detail="❌ ERROR: Invalid webhook signature"
-        )
+        raise HTTPException(status_code=401, detail="❌ ERROR: Invalid webhook signature")
 
 
 def _validate_logging_configuration() -> None:
@@ -131,9 +125,7 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
     _verify_signature(secret, body, signature)
 
     if not event:
-        raise HTTPException(
-            status_code=400, detail="❌ ERROR: Missing X-GitHub-Event header"
-        )
+        raise HTTPException(status_code=400, detail="❌ ERROR: Missing X-GitHub-Event header")
 
     payload = await request.json()
     settings = _get_settings()

--- a/src/ace/webhooks/app.py
+++ b/src/ace/webhooks/app.py
@@ -18,6 +18,19 @@ from ace.notifications.slack_client import (
     format_webhook_message,
 )
 from ace.webhooks.handlers import WebhookHandler
+from ace.webhooks.lifecycle import (
+    STAGE_AGENT_FINISHED,
+    STAGE_AGENT_STARTED,
+    STAGE_FINAL_RESOLUTION,
+    STAGE_WEBHOOK_ENQUEUED,
+    STAGE_WEBHOOK_RECEIVED,
+    STAGE_WORKER_DEQUEUED,
+    STAGE_WORKER_STARTED,
+    build_lifecycle_context,
+    log_lifecycle_event,
+    normalize_error_resolution,
+    normalize_result_resolution,
+)
 from ace.webhooks.pubsub_queue import PubSubWebhookQueue, decode_pubsub_push
 
 logger = structlog.get_logger(__name__)
@@ -33,6 +46,7 @@ _settings: Settings | None = None
 async def _startup() -> None:
     settings = _get_settings()
     configure_logging(debug=settings.debug)
+    _validate_logging_configuration()
     global _notifier
     _notifier = SlackNotifier.from_settings(settings)
     logger.info("webhook_listener_started", role=settings.webhook_service_role)
@@ -92,6 +106,17 @@ def _verify_signature(secret: str, body: bytes, signature: str | None) -> None:
         )
 
 
+def _validate_logging_configuration() -> None:
+    """Require JSON logs on Cloud Run so lifecycle fields are queryable."""
+    if not os.getenv("K_SERVICE"):
+        return
+    log_format = os.getenv("ACE_LOG_FORMAT", "console").strip().lower()
+    if log_format != "json":
+        raise RuntimeError(
+            "❌ ERROR: ACE_LOG_FORMAT must be set to json for Cloud Run webhook services."
+        )
+
+
 @app.post("/github/webhooks", status_code=202)
 async def github_webhooks(request: Request) -> dict[str, Any]:
     if not _listener_enabled():
@@ -111,10 +136,37 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
         )
 
     payload = await request.json()
+    settings = _get_settings()
+    context = build_lifecycle_context(
+        event=event,
+        payload=payload,
+        delivery=delivery,
+        default_project=getattr(settings, "github_project_name", None),
+    )
+    log_lifecycle_event(logger, STAGE_WEBHOOK_RECEIVED, context)
 
     try:
-        message_id = await _get_queue().publish(event=event, payload=payload, delivery=delivery)
+        message_id = await _get_queue().publish(
+            event=event,
+            payload=payload,
+            delivery=delivery,
+            workflow_id=context.workflow_id,
+        )
+        log_lifecycle_event(
+            logger,
+            STAGE_WEBHOOK_ENQUEUED,
+            context,
+            message_id=message_id,
+            pubsub_topic=getattr(settings, "webhook_pubsub_topic", None),
+        )
     except Exception as exc:
+        log_lifecycle_event(
+            logger,
+            STAGE_FINAL_RESOLUTION,
+            context,
+            resolution=normalize_error_resolution(exc),
+            error=f"❌ ERROR: {exc}",
+        )
         if _notifier is not None:
             await _notifier.safe_post(format_error_message(event, delivery, exc))
         raise HTTPException(
@@ -126,6 +178,7 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
         "status": "queued",
         "event": event,
         "delivery": delivery,
+        "workflow_id": context.workflow_id,
         "message_id": message_id,
     }
 
@@ -141,10 +194,57 @@ async def pubsub_worker(request: Request) -> dict[str, Any]:
     except Exception as exc:
         raise HTTPException(status_code=400, detail=f"{exc}") from exc
 
+    settings = _get_settings()
+    context = build_lifecycle_context(
+        event=queued.event,
+        payload=queued.payload,
+        delivery=queued.delivery,
+        workflow_id=queued.workflow_id,
+        default_project=getattr(settings, "github_project_name", None),
+    )
+    log_lifecycle_event(
+        logger,
+        STAGE_WORKER_DEQUEUED,
+        context,
+        message_id=queued.message_id,
+    )
+
+    log_lifecycle_event(
+        logger,
+        STAGE_WORKER_STARTED,
+        context,
+        message_id=queued.message_id,
+    )
+
     handler = _get_handler()
+    log_lifecycle_event(logger, STAGE_AGENT_STARTED, context)
     try:
         result = await handler.handle(queued.event, queued.payload, queued.delivery)
+        log_lifecycle_event(
+            logger,
+            STAGE_AGENT_FINISHED,
+            context,
+            handler_status=result.get("status"),
+            handler_action=result.get("action"),
+        )
+        resolution = normalize_result_resolution(result)
+        log_lifecycle_event(
+            logger,
+            STAGE_FINAL_RESOLUTION,
+            context,
+            resolution=resolution,
+            handler_status=result.get("status"),
+            handler_action=result.get("action"),
+        )
     except Exception as exc:
+        resolution = normalize_error_resolution(exc)
+        log_lifecycle_event(
+            logger,
+            STAGE_FINAL_RESOLUTION,
+            context,
+            resolution=resolution,
+            error=f"❌ ERROR: {exc}",
+        )
         if _notifier is not None:
             await _notifier.safe_post(format_error_message(queued.event, queued.delivery, exc))
         raise
@@ -158,6 +258,8 @@ async def pubsub_worker(request: Request) -> dict[str, Any]:
         "status": "ok",
         "event": queued.event,
         "delivery": queued.delivery,
+        "workflow_id": context.workflow_id,
         "message_id": queued.message_id,
+        "resolution": resolution,
         "result": result,
     }

--- a/src/ace/webhooks/github_app.py
+++ b/src/ace/webhooks/github_app.py
@@ -72,9 +72,7 @@ class GitHubAppAuth:
                 status=response.status_code,
                 body=response.text,
             )
-            raise ValueError(
-                f"❌ ERROR: GitHub App token request failed ({response.status_code})"
-            )
+            raise ValueError(f"❌ ERROR: GitHub App token request failed ({response.status_code})")
 
         payload = response.json()
         token = payload.get("token")

--- a/src/ace/webhooks/handlers.py
+++ b/src/ace/webhooks/handlers.py
@@ -31,7 +31,9 @@ class WebhookHandler:
         self.settings = get_settings()
         self.app_auth = GitHubAppAuth.from_env()
 
-    async def handle(self, event: str, payload: dict[str, Any], delivery: str | None) -> dict[str, Any]:
+    async def handle(
+        self, event: str, payload: dict[str, Any], delivery: str | None
+    ) -> dict[str, Any]:
         if event == "projects_v2_item":
             return await self._handle_projects_v2_item(payload, delivery)
         if event == "issue_comment":
@@ -234,7 +236,9 @@ class WebhookHandler:
             return {
                 "status": "triggered",
                 "action": "blocker_closed",
-                "closed_issue": f"{closed_issue.repo_owner}/{closed_issue.repo_name}#{closed_issue.number}",
+                "closed_issue": (
+                    f"{closed_issue.repo_owner}/{closed_issue.repo_name}#{closed_issue.number}"
+                ),
                 "triggered_count": len(triggered),
                 "results": triggered,
             }
@@ -381,17 +385,15 @@ def _normalize_status(value: Any) -> str | None:
 
 
 def _is_ready_transition(transition: StatusTransition) -> bool:
-    return (
-        (transition.from_status or "").lower() == "backlog"
-        and (transition.to_status or "").lower() == "ready"
-    )
+    return (transition.from_status or "").lower() == "backlog" and (
+        transition.to_status or ""
+    ).lower() == "ready"
 
 
 def _is_in_progress_transition(transition: StatusTransition) -> bool:
-    return (
-        (transition.from_status or "").lower() == "blocked"
-        and (transition.to_status or "").lower() == "in progress"
-    )
+    return (transition.from_status or "").lower() == "blocked" and (
+        transition.to_status or ""
+    ).lower() == "in progress"
 
 
 def _extract_issue_from_payload(payload: dict[str, Any]) -> IssueInfo | None:

--- a/src/ace/webhooks/lifecycle.py
+++ b/src/ace/webhooks/lifecycle.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 
 import structlog
 
-
 STAGE_WEBHOOK_RECEIVED = "webhook_received"
 STAGE_WEBHOOK_ENQUEUED = "webhook_enqueued"
 STAGE_WORKER_DEQUEUED = "worker_dequeued"
@@ -43,8 +42,13 @@ def build_lifecycle_context(
     default_project: str | None = None,
 ) -> WebhookLifecycleContext:
     """Build a normalized lifecycle context for listener and worker logs."""
-    normalized_delivery = delivery.strip() if isinstance(delivery, str) and delivery.strip() else None
-    resolved_workflow_id = _resolve_workflow_id(workflow_id=workflow_id, delivery=normalized_delivery)
+    normalized_delivery = (
+        delivery.strip() if isinstance(delivery, str) and delivery.strip() else None
+    )
+    resolved_workflow_id = _resolve_workflow_id(
+        workflow_id=workflow_id,
+        delivery=normalized_delivery,
+    )
     action = payload.get("action")
     if not isinstance(action, str) or not action.strip():
         action = None
@@ -160,7 +164,9 @@ def _extract_issue_key(payload: dict[str, Any]) -> str | None:
             if isinstance(content, dict):
                 number = content.get("number")
                 if not repo_owner or not repo_name:
-                    repo_owner, repo_name = _extract_repository({"repository": content.get("repository")})
+                    repo_owner, repo_name = _extract_repository(
+                        {"repository": content.get("repository")}
+                    )
 
     if number is None:
         return None

--- a/src/ace/webhooks/lifecycle.py
+++ b/src/ace/webhooks/lifecycle.py
@@ -1,0 +1,195 @@
+"""Canonical lifecycle logging for webhook listener/worker processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+import structlog
+
+
+STAGE_WEBHOOK_RECEIVED = "webhook_received"
+STAGE_WEBHOOK_ENQUEUED = "webhook_enqueued"
+STAGE_WORKER_DEQUEUED = "worker_dequeued"
+STAGE_WORKER_STARTED = "worker_started"
+STAGE_AGENT_STARTED = "agent_started"
+STAGE_AGENT_FINISHED = "agent_finished"
+STAGE_FINAL_RESOLUTION = "final_resolution"
+
+RESOLUTION_SUCCESS = "success"
+RESOLUTION_BLOCKED = "blocked"
+RESOLUTION_FAILURE = "failure"
+RESOLUTION_TIMEOUT = "timeout"
+RESOLUTION_PR_OPENED = "pr_opened"
+
+
+@dataclass(frozen=True)
+class WebhookLifecycleContext:
+    event: str
+    action: str | None
+    project: str | None
+    issue_key: str | None
+    delivery_id: str | None
+    workflow_id: str
+
+
+def build_lifecycle_context(
+    *,
+    event: str,
+    payload: dict[str, Any],
+    delivery: str | None,
+    workflow_id: str | None = None,
+    default_project: str | None = None,
+) -> WebhookLifecycleContext:
+    """Build a normalized lifecycle context for listener and worker logs."""
+    normalized_delivery = delivery.strip() if isinstance(delivery, str) and delivery.strip() else None
+    resolved_workflow_id = _resolve_workflow_id(workflow_id=workflow_id, delivery=normalized_delivery)
+    action = payload.get("action")
+    if not isinstance(action, str) or not action.strip():
+        action = None
+
+    return WebhookLifecycleContext(
+        event=event,
+        action=action,
+        project=_extract_project(payload, default_project=default_project),
+        issue_key=_extract_issue_key(payload),
+        delivery_id=normalized_delivery,
+        workflow_id=resolved_workflow_id,
+    )
+
+
+def log_lifecycle_event(
+    logger: structlog.BoundLogger,
+    stage: str,
+    context: WebhookLifecycleContext,
+    *,
+    resolution: str | None = None,
+    **fields: Any,
+) -> None:
+    """Emit a structured lifecycle log entry with canonical correlation fields."""
+    bound_logger = logger.bind(
+        event=context.event,
+        action=context.action,
+        project=context.project,
+        issue_key=context.issue_key,
+        delivery_id=context.delivery_id,
+        workflow_id=context.workflow_id,
+    )
+    data = {"stage": stage}
+    if resolution is not None:
+        data["resolution"] = resolution
+    data.update(fields)
+    bound_logger.info("webhook_lifecycle", **data)
+
+
+def normalize_result_resolution(result: dict[str, Any]) -> str:
+    """Map handler results to a normalized resolution value."""
+    status = _to_lower(result.get("status"))
+    action = _to_lower(result.get("action"))
+    if status == "blocked":
+        return RESOLUTION_BLOCKED
+    if status in {"timeout", "task_wait_timeout"}:
+        return RESOLUTION_TIMEOUT
+    if status in {"failure", "failed", "error"}:
+        return RESOLUTION_FAILURE
+    if action == "pr_opened" or "pr_number" in result:
+        return RESOLUTION_PR_OPENED
+
+    nested = result.get("result")
+    if isinstance(nested, dict):
+        nested_status = _to_lower(nested.get("status"))
+        if nested_status in {"timeout", "task_wait_timeout"}:
+            return RESOLUTION_TIMEOUT
+        if nested_status in {"failure", "failed", "error"}:
+            return RESOLUTION_FAILURE
+        if nested_status == "blocked":
+            return RESOLUTION_BLOCKED
+        if nested_status == "pr_opened" or "pr_number" in nested:
+            return RESOLUTION_PR_OPENED
+
+    return RESOLUTION_SUCCESS
+
+
+def normalize_error_resolution(exc: Exception) -> str:
+    """Normalize exception outcomes for lifecycle logging."""
+    text = str(exc).lower()
+    if "timeout" in text:
+        return RESOLUTION_TIMEOUT
+    return RESOLUTION_FAILURE
+
+
+def _resolve_workflow_id(*, workflow_id: str | None, delivery: str | None) -> str:
+    if isinstance(workflow_id, str) and workflow_id.strip():
+        return workflow_id.strip()
+    if delivery:
+        return delivery
+    return f"wf-{uuid4().hex}"
+
+
+def _extract_project(payload: dict[str, Any], *, default_project: str | None) -> str | None:
+    project = payload.get("project")
+    if isinstance(project, dict):
+        title = project.get("title")
+        if isinstance(title, str) and title.strip():
+            return title.strip()
+
+    item = payload.get("projects_v2_item") or payload.get("project_v2_item") or {}
+    if isinstance(item, dict):
+        for key in ("project_title", "projectTitle", "project_name", "projectName"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    if isinstance(default_project, str) and default_project.strip():
+        return default_project.strip()
+    return None
+
+
+def _extract_issue_key(payload: dict[str, Any]) -> str | None:
+    repo_owner, repo_name = _extract_repository(payload)
+    issue = payload.get("issue")
+    number = None
+    if isinstance(issue, dict):
+        number = issue.get("number")
+
+    if number is None:
+        item = payload.get("projects_v2_item") or payload.get("project_v2_item") or {}
+        if isinstance(item, dict):
+            content = item.get("content")
+            if isinstance(content, dict):
+                number = content.get("number")
+                if not repo_owner or not repo_name:
+                    repo_owner, repo_name = _extract_repository({"repository": content.get("repository")})
+
+    if number is None:
+        return None
+    try:
+        number_int = int(number)
+    except (TypeError, ValueError):
+        return None
+
+    if not repo_owner or not repo_name:
+        return None
+    return f"{repo_owner}/{repo_name}#{number_int}"
+
+
+def _extract_repository(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    repo = payload.get("repository")
+    if not isinstance(repo, dict):
+        return None, None
+
+    name = repo.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None, None
+
+    owner = repo.get("owner")
+    if isinstance(owner, dict):
+        owner = owner.get("login")
+    if not isinstance(owner, str) or not owner.strip():
+        return None, None
+    return owner.strip(), name.strip()
+
+
+def _to_lower(value: Any) -> str:
+    return str(value).strip().lower() if value is not None else ""

--- a/src/ace/webhooks/pubsub_queue.py
+++ b/src/ace/webhooks/pubsub_queue.py
@@ -33,9 +33,7 @@ class PubSubWebhookQueue:
     def from_settings(cls, settings: Settings) -> PubSubWebhookQueue:
         topic_path = (settings.webhook_pubsub_topic or "").strip()
         if not topic_path:
-            raise ValueError(
-                "❌ ERROR: WEBHOOK_PUBSUB_TOPIC is required for listener mode."
-            )
+            raise ValueError("❌ ERROR: WEBHOOK_PUBSUB_TOPIC is required for listener mode.")
         if not topic_path.startswith("projects/"):
             raise ValueError(
                 "❌ ERROR: WEBHOOK_PUBSUB_TOPIC must be a full topic path "

--- a/src/ace/webhooks/pubsub_queue.py
+++ b/src/ace/webhooks/pubsub_queue.py
@@ -18,6 +18,7 @@ class QueuedWebhookEvent:
     event: str
     payload: dict[str, Any]
     delivery: str | None
+    workflow_id: str | None = None
     message_id: str | None = None
 
 
@@ -43,8 +44,20 @@ class PubSubWebhookQueue:
         publisher = pubsub_v1.PublisherClient()
         return cls(publisher=publisher, topic_path=topic_path)
 
-    async def publish(self, *, event: str, payload: dict[str, Any], delivery: str | None) -> str:
-        envelope = {"event": event, "payload": payload, "delivery": delivery}
+    async def publish(
+        self,
+        *,
+        event: str,
+        payload: dict[str, Any],
+        delivery: str | None,
+        workflow_id: str | None = None,
+    ) -> str:
+        envelope = {
+            "event": event,
+            "payload": payload,
+            "delivery": delivery,
+            "workflow_id": workflow_id,
+        }
         body = json.dumps(envelope, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
         attrs = {"event": event}
         if delivery:
@@ -76,6 +89,7 @@ def decode_pubsub_push(body: dict[str, Any]) -> QueuedWebhookEvent:
     event = envelope.get("event")
     payload = envelope.get("payload")
     delivery = envelope.get("delivery")
+    workflow_id = envelope.get("workflow_id")
     message_id = message.get("messageId")
 
     if not isinstance(event, str) or not event:
@@ -84,6 +98,8 @@ def decode_pubsub_push(body: dict[str, Any]) -> QueuedWebhookEvent:
         raise ValueError("❌ ERROR: invalid_pubsub_push: payload must be an object")
     if delivery is not None and not isinstance(delivery, str):
         raise ValueError("❌ ERROR: invalid_pubsub_push: delivery must be string or null")
+    if workflow_id is not None and not isinstance(workflow_id, str):
+        raise ValueError("❌ ERROR: invalid_pubsub_push: workflow_id must be string or null")
     if message_id is not None and not isinstance(message_id, str):
         raise ValueError("❌ ERROR: invalid_pubsub_push: messageId must be string")
 
@@ -91,5 +107,6 @@ def decode_pubsub_push(body: dict[str, Any]) -> QueuedWebhookEvent:
         event=event,
         payload=payload,
         delivery=delivery,
+        workflow_id=workflow_id,
         message_id=message_id,
     )

--- a/src/ace/workspaces/git_ops.py
+++ b/src/ace/workspaces/git_ops.py
@@ -64,9 +64,7 @@ class GitOps:
         user = parts.username or ""
         redacted = f"{user}:***@" if user else "***@"
         netloc = f"{redacted}{hostname}"
-        return urlunsplit(
-            (parts.scheme, netloc, parts.path, parts.query, parts.fragment)
-        )
+        return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
     def _resolve_default_branch(self, worktree_path: Path) -> str:
         """Resolve the remote default branch from origin/HEAD."""
@@ -89,16 +87,12 @@ class GitOps:
                 returncode=result.returncode,
                 stderr=result.stderr.decode() if result.stderr else "",
             )
-            raise RuntimeError(
-                "❌ ERROR: Unable to resolve default branch from origin/HEAD"
-            )
+            raise RuntimeError("❌ ERROR: Unable to resolve default branch from origin/HEAD")
 
         ref = result.stdout.decode().strip()
         if not ref:
             logger.error("❌ ERROR: default_branch_resolve_empty")
-            raise RuntimeError(
-                "❌ ERROR: Unable to resolve default branch from origin/HEAD"
-            )
+            raise RuntimeError("❌ ERROR: Unable to resolve default branch from origin/HEAD")
 
         if ref.startswith("origin/"):
             return ref.split("/", 1)[1]
@@ -125,9 +119,7 @@ class GitOps:
         worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
         safe_repo_url = self._sanitize_repo_url(repo_url)
-        logger.info(
-            "cloning_repo", repo_url=safe_repo_url, worktree_path=str(worktree_path)
-        )
+        logger.info("cloning_repo", repo_url=safe_repo_url, worktree_path=str(worktree_path))
 
         env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
         clone_cmd = [
@@ -187,9 +179,7 @@ class GitOps:
                 timeout=120,
             )
 
-            resolved_base_branch = base_branch or self._resolve_default_branch(
-                worktree_path
-            )
+            resolved_base_branch = base_branch or self._resolve_default_branch(worktree_path)
             logger.info(
                 "ensuring_branch",
                 branch=branch_name,
@@ -253,9 +243,7 @@ class GitOps:
         logger.info("creating_branch", branch=branch_name, worktree=str(worktree_path))
 
         try:
-            resolved_base_branch = base_branch or self._resolve_default_branch(
-                worktree_path
-            )
+            resolved_base_branch = base_branch or self._resolve_default_branch(worktree_path)
             subprocess.run(
                 [
                     "git",

--- a/src/ace/workspaces/tmux_ops.py
+++ b/src/ace/workspaces/tmux_ops.py
@@ -170,13 +170,9 @@ class TmuxOps:
             if result.returncode == 0:
                 return
             last_error = result.stderr.decode("utf-8", errors="replace").strip()
-        raise RuntimeError(
-            f"failed to send Enter to tmux session '{session_name}': {last_error}"
-        )
+        raise RuntimeError(f"failed to send Enter to tmux session '{session_name}': {last_error}")
 
-    def send_prompt(
-        self, session_name: str, prompt: str, delay_seconds: float = 1.0
-    ) -> None:
+    def send_prompt(self, session_name: str, prompt: str, delay_seconds: float = 1.0) -> None:
         """Send a prompt to an existing session (chunked) and hit Enter twice."""
         if not prompt:
             return
@@ -204,9 +200,7 @@ class TmuxOps:
             )
             time.sleep(0.1)
 
-    def send_enter(
-        self, session_name: str, repeat: int = 1, delay_seconds: float = 0.0
-    ) -> None:
+    def send_enter(self, session_name: str, repeat: int = 1, delay_seconds: float = 0.0) -> None:
         """Send one or more Enter keypresses to a session."""
         if not self.session_exists(session_name):
             raise RuntimeError(f"tmux session '{session_name}' not found")
@@ -239,8 +233,6 @@ class TmuxOps:
         if result.returncode != 0:
             error = result.stderr.strip()
             logger.warning("tmux_capture_failed", session=session_name, error=error)
-            raise RuntimeError(
-                f"failed to capture tmux session '{session_name}': {error}"
-            )
+            raise RuntimeError(f"failed to capture tmux session '{session_name}': {error}")
 
         return result.stdout

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,7 +1,5 @@
 """Tests for git operations."""
 
-import pytest
-
 from ace.workspaces.git_ops import GitOps
 
 

--- a/tests/test_slack_notifications.py
+++ b/tests/test_slack_notifications.py
@@ -49,8 +49,15 @@ def test_webhook_listener_enqueues_pubsub(monkeypatch):
     published = []
 
     class StubQueue:
-        async def publish(self, *, event, payload, delivery):
-            published.append({"event": event, "payload": payload, "delivery": delivery})
+        async def publish(self, *, event, payload, delivery, workflow_id=None):
+            published.append(
+                {
+                    "event": event,
+                    "payload": payload,
+                    "delivery": delivery,
+                    "workflow_id": workflow_id,
+                }
+            )
             return "msg-123"
 
     # Patch globals used by the FastAPI endpoint.
@@ -92,6 +99,7 @@ def test_webhook_listener_enqueues_pubsub(monkeypatch):
         assert published
         assert published[0]["event"] == "issue_comment"
         assert published[0]["delivery"] == "delivery-1"
+        assert published[0]["workflow_id"] == "delivery-1"
         assert published[0]["payload"] == {"hello": "world"}
     finally:
         webhook_app._queue = old_queue
@@ -154,7 +162,180 @@ def test_webhook_worker_success_sends_slack(monkeypatch):
         assert posted
         assert "Webhook processed" in posted[0]
         assert "event=issue_comment" in posted[0]
+        assert resp.json()["workflow_id"] == "delivery-1"
+        assert resp.json()["resolution"] == "success"
     finally:
+        webhook_app._handler = old_handler
+        webhook_app._notifier = old_notifier
+        webhook_app._settings = old_settings
+
+
+def test_webhook_listener_lifecycle_logs(monkeypatch):
+    from ace.webhooks import app as webhook_app
+
+    events = []
+
+    class StubLogger:
+        def __init__(self):
+            self._bound = {}
+
+        def bind(self, **kwargs):
+            self._bound.update(kwargs)
+            return self
+
+        def info(self, event_name, **fields):
+            merged = dict(self._bound)
+            merged.update(fields)
+            events.append({"event_name": event_name, "fields": merged})
+
+    class StubQueue:
+        async def publish(self, *, event, payload, delivery, workflow_id=None):
+            return "msg-xyz"
+
+    old_logger = webhook_app.logger
+    old_queue = webhook_app._queue
+    old_settings = webhook_app._settings
+    webhook_app.logger = StubLogger()
+    webhook_app._queue = StubQueue()
+    webhook_app._settings = type(
+        "SettingsStub",
+        (),
+        {
+            "webhook_service_role": "listener",
+            "github_project_name": "Appforge",
+            "webhook_pubsub_topic": "projects/p/topics/t",
+            "debug": False,
+            "slack_bot_token": "",
+            "slack_channel_id": "",
+        },
+    )()
+
+    secret = "test-secret"
+    os.environ["GITHUB_WEBHOOK_SECRET"] = secret
+    payload = {
+        "action": "created",
+        "issue": {"number": 34},
+        "repository": {"name": "digido", "owner": {"login": "Day-in-the-Country-LLC"}},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    mac = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256)
+    sig = f"sha256={mac.hexdigest()}"
+
+    try:
+        client = TestClient(webhook_app.app)
+        resp = client.post(
+            "/github/webhooks",
+            data=body,
+            headers={
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Event": "issue_comment",
+                "X-GitHub-Delivery": "delivery-42",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 202
+        lifecycle = [e for e in events if e["event_name"] == "webhook_lifecycle"]
+        assert [e["fields"]["stage"] for e in lifecycle] == ["webhook_received", "webhook_enqueued"]
+        for entry in lifecycle:
+            fields = entry["fields"]
+            assert fields["event"] == "issue_comment"
+            assert fields["delivery_id"] == "delivery-42"
+            assert fields["workflow_id"] == "delivery-42"
+            assert fields["issue_key"] == "Day-in-the-Country-LLC/digido#34"
+            assert fields["project"] == "Appforge"
+    finally:
+        webhook_app.logger = old_logger
+        webhook_app._queue = old_queue
+        webhook_app._settings = old_settings
+
+
+def test_webhook_worker_lifecycle_logs_blocked(monkeypatch):
+    from ace.webhooks import app as webhook_app
+
+    events = []
+
+    class StubLogger:
+        def __init__(self):
+            self._bound = {}
+
+        def bind(self, **kwargs):
+            self._bound.update(kwargs)
+            return self
+
+        def info(self, event_name, **fields):
+            merged = dict(self._bound)
+            merged.update(fields)
+            events.append({"event_name": event_name, "fields": merged})
+
+    class StubHandler:
+        async def handle(self, event, payload, delivery):
+            return {"status": "blocked", "action": "Ready"}
+
+    old_logger = webhook_app.logger
+    old_handler = webhook_app._handler
+    old_notifier = webhook_app._notifier
+    old_settings = webhook_app._settings
+    webhook_app.logger = StubLogger()
+    webhook_app._handler = StubHandler()
+    webhook_app._notifier = None
+    webhook_app._settings = type(
+        "SettingsStub",
+        (),
+        {
+            "webhook_service_role": "worker",
+            "github_project_name": "Appforge",
+            "debug": False,
+            "slack_bot_token": "",
+            "slack_channel_id": "",
+        },
+    )()
+
+    envelope = {
+        "message": {
+            "messageId": "1234",
+            "data": base64.b64encode(
+                json.dumps(
+                    {
+                        "event": "projects_v2_item",
+                        "delivery": "delivery-11",
+                        "workflow_id": "wf-11",
+                        "payload": {
+                            "action": "edited",
+                            "issue": {"number": 34},
+                            "repository": {
+                                "name": "digido",
+                                "owner": {"login": "Day-in-the-Country-LLC"},
+                            },
+                        },
+                    }
+                ).encode("utf-8")
+            ).decode("utf-8"),
+        }
+    }
+
+    try:
+        client = TestClient(webhook_app.app)
+        resp = client.post("/internal/pubsub/worker", json=envelope)
+        assert resp.status_code == 200
+        assert resp.json()["resolution"] == "blocked"
+
+        lifecycle = [e for e in events if e["event_name"] == "webhook_lifecycle"]
+        assert [e["fields"]["stage"] for e in lifecycle] == [
+            "worker_dequeued",
+            "worker_started",
+            "agent_started",
+            "agent_finished",
+            "final_resolution",
+        ]
+        for entry in lifecycle:
+            fields = entry["fields"]
+            assert fields["workflow_id"] == "wf-11"
+            assert fields["delivery_id"] == "delivery-11"
+            assert fields["issue_key"] == "Day-in-the-Country-LLC/digido#34"
+
+        assert lifecycle[-1]["fields"]["resolution"] == "blocked"
+    finally:
+        webhook_app.logger = old_logger
         webhook_app._handler = old_handler
         webhook_app._notifier = old_notifier
         webhook_app._settings = old_settings

--- a/tests/test_slack_notifications.py
+++ b/tests/test_slack_notifications.py
@@ -77,7 +77,7 @@ def test_webhook_listener_enqueues_pubsub(monkeypatch):
 
     secret = "test-secret"
     os.environ["GITHUB_WEBHOOK_SECRET"] = secret
-    body = b"{\"hello\":\"world\"}"
+    body = b'{"hello":"world"}'
     mac = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256)
     sig = f"sha256={mac.hexdigest()}"
 

--- a/tests/test_webhook_lifecycle.py
+++ b/tests/test_webhook_lifecycle.py
@@ -1,0 +1,53 @@
+from ace.webhooks.lifecycle import (
+    RESOLUTION_BLOCKED,
+    RESOLUTION_FAILURE,
+    RESOLUTION_PR_OPENED,
+    RESOLUTION_SUCCESS,
+    RESOLUTION_TIMEOUT,
+    build_lifecycle_context,
+    normalize_error_resolution,
+    normalize_result_resolution,
+)
+
+
+def test_build_lifecycle_context_extracts_issue_and_project():
+    context = build_lifecycle_context(
+        event="issue_comment",
+        payload={
+            "action": "created",
+            "project": {"title": "Appforge"},
+            "issue": {"number": 12},
+            "repository": {"name": "digido", "owner": {"login": "Day-in-the-Country-LLC"}},
+        },
+        delivery="delivery-123",
+    )
+    assert context.event == "issue_comment"
+    assert context.action == "created"
+    assert context.project == "Appforge"
+    assert context.issue_key == "Day-in-the-Country-LLC/digido#12"
+    assert context.delivery_id == "delivery-123"
+    assert context.workflow_id == "delivery-123"
+
+
+def test_build_lifecycle_context_uses_default_project_and_generated_workflow_id():
+    context = build_lifecycle_context(
+        event="projects_v2_item",
+        payload={},
+        delivery=None,
+        default_project="Default Project",
+    )
+    assert context.project == "Default Project"
+    assert context.workflow_id.startswith("wf-")
+
+
+def test_normalize_result_resolution():
+    assert normalize_result_resolution({"status": "blocked"}) == RESOLUTION_BLOCKED
+    assert normalize_result_resolution({"status": "failed"}) == RESOLUTION_FAILURE
+    assert normalize_result_resolution({"status": "task_wait_timeout"}) == RESOLUTION_TIMEOUT
+    assert normalize_result_resolution({"action": "pr_opened"}) == RESOLUTION_PR_OPENED
+    assert normalize_result_resolution({"status": "triggered"}) == RESOLUTION_SUCCESS
+
+
+def test_normalize_error_resolution():
+    assert normalize_error_resolution(RuntimeError("task_wait_timeout")) == RESOLUTION_TIMEOUT
+    assert normalize_error_resolution(RuntimeError("boom")) == RESOLUTION_FAILURE


### PR DESCRIPTION
## Summary
- add a canonical webhook lifecycle logging module with normalized stages and resolution mapping
- emit structured lifecycle events across listener and worker with shared correlation fields (`issue_key`, `delivery_id`, `workflow_id`, `project`, `action`, `event`)
- propagate `workflow_id` through Pub/Sub envelope/push decoding and include normalized `resolution` in worker responses
- enforce `ACE_LOG_FORMAT=json` on Cloud Run startup for webhook services and document deployment requirements
- expand tests for lifecycle context extraction, lifecycle stage emission, and resolution normalization

## Testing
- `uv run pytest`

Closes #4
