### PR TITLE
Propagate Pub/Sub correlation IDs through worker lifecycle logs

### DIFF
--- a/docs/webhook-listener.md
+++ b/docs/webhook-listener.md
@@ -191,6 +191,39 @@ Worker service:
 - Deployment target: Cloud Run
 - Behavior: decodes Pub/Sub push payload, runs `WebhookHandler.handle(...)`, sends Slack status/error notifications
 
+Pub/Sub payload/envelope schema (v2):
+
+- `event`
+- `payload`
+- `delivery`
+- `workflow_id`
+- `queued_at`
+- `correlation.delivery_id`
+- `correlation.workflow_id`
+- `correlation.issue_key`
+- `correlation.project`
+- `correlation.action`
+
+Pub/Sub message attributes carry the same correlation values when available:
+
+- `delivery_id`
+- `workflow_id`
+- `issue_key`
+- `project`
+- `action`
+- `queued_at`
+
+Worker lifecycle logs include:
+
+- `pubsub_message_id`
+- `workflow_id`
+- `delivery_id`
+- `issue_key`
+- `project`
+- `queued_at`
+- `dequeued_at`
+- `queue_delay_ms`
+
 Recommended Cloud Run concurrency:
 
 - Listener: high concurrency (e.g. `40` or default) because work is short-lived enqueue.

--- a/src/ace/webhooks/app.py
+++ b/src/ace/webhooks/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -111,6 +112,26 @@ def _validate_logging_configuration() -> None:
         )
 
 
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _queue_delay_ms(*, queued_at: str | None, dequeued_at: str) -> float | None:
+    if not queued_at:
+        return None
+    try:
+        queued_dt = datetime.fromisoformat(queued_at.replace("Z", "+00:00"))
+        dequeued_dt = datetime.fromisoformat(dequeued_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if queued_dt.tzinfo is None:
+        queued_dt = queued_dt.replace(tzinfo=UTC)
+    if dequeued_dt.tzinfo is None:
+        dequeued_dt = dequeued_dt.replace(tzinfo=UTC)
+    delay_ms = (dequeued_dt - queued_dt).total_seconds() * 1000
+    return round(delay_ms, 3)
+
+
 @app.post("/github/webhooks", status_code=202)
 async def github_webhooks(request: Request) -> dict[str, Any]:
     if not _listener_enabled():
@@ -135,6 +156,7 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
         delivery=delivery,
         default_project=getattr(settings, "github_project_name", None),
     )
+    queued_at = _utc_now_iso()
     log_lifecycle_event(logger, STAGE_WEBHOOK_RECEIVED, context)
 
     try:
@@ -143,12 +165,18 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
             payload=payload,
             delivery=delivery,
             workflow_id=context.workflow_id,
+            issue_key=context.issue_key,
+            project=context.project,
+            action=context.action,
+            queued_at=queued_at,
         )
         log_lifecycle_event(
             logger,
             STAGE_WEBHOOK_ENQUEUED,
             context,
             message_id=message_id,
+            pubsub_message_id=message_id,
+            queued_at=queued_at,
             pubsub_topic=getattr(settings, "webhook_pubsub_topic", None),
         )
     except Exception as exc:
@@ -171,7 +199,9 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
         "event": event,
         "delivery": delivery,
         "workflow_id": context.workflow_id,
+        "queued_at": queued_at,
         "message_id": message_id,
+        "pubsub_message_id": message_id,
     }
 
 
@@ -193,12 +223,21 @@ async def pubsub_worker(request: Request) -> dict[str, Any]:
         delivery=queued.delivery,
         workflow_id=queued.workflow_id,
         default_project=getattr(settings, "github_project_name", None),
+        project=queued.project,
+        issue_key=queued.issue_key,
+        action=queued.action,
     )
+    dequeued_at = _utc_now_iso()
+    queue_delay_ms = _queue_delay_ms(queued_at=queued.queued_at, dequeued_at=dequeued_at)
     log_lifecycle_event(
         logger,
         STAGE_WORKER_DEQUEUED,
         context,
         message_id=queued.message_id,
+        pubsub_message_id=queued.message_id,
+        queued_at=queued.queued_at,
+        dequeued_at=dequeued_at,
+        queue_delay_ms=queue_delay_ms,
     )
 
     log_lifecycle_event(
@@ -206,6 +245,9 @@ async def pubsub_worker(request: Request) -> dict[str, Any]:
         STAGE_WORKER_STARTED,
         context,
         message_id=queued.message_id,
+        pubsub_message_id=queued.message_id,
+        queued_at=queued.queued_at,
+        queue_delay_ms=queue_delay_ms,
     )
 
     handler = _get_handler()
@@ -251,7 +293,10 @@ async def pubsub_worker(request: Request) -> dict[str, Any]:
         "event": queued.event,
         "delivery": queued.delivery,
         "workflow_id": context.workflow_id,
+        "queued_at": queued.queued_at,
+        "queue_delay_ms": queue_delay_ms,
         "message_id": queued.message_id,
+        "pubsub_message_id": queued.message_id,
         "resolution": resolution,
         "result": result,
     }

--- a/src/ace/webhooks/lifecycle.py
+++ b/src/ace/webhooks/lifecycle.py
@@ -40,6 +40,9 @@ def build_lifecycle_context(
     delivery: str | None,
     workflow_id: str | None = None,
     default_project: str | None = None,
+    project: str | None = None,
+    issue_key: str | None = None,
+    action: str | None = None,
 ) -> WebhookLifecycleContext:
     """Build a normalized lifecycle context for listener and worker logs."""
     normalized_delivery = (
@@ -49,15 +52,29 @@ def build_lifecycle_context(
         workflow_id=workflow_id,
         delivery=normalized_delivery,
     )
-    action = payload.get("action")
-    if not isinstance(action, str) or not action.strip():
-        action = None
+    resolved_action = action
+    if not isinstance(resolved_action, str) or not resolved_action.strip():
+        resolved_action = payload.get("action")
+    if not isinstance(resolved_action, str) or not resolved_action.strip():
+        resolved_action = None
+
+    resolved_project = project
+    if not isinstance(resolved_project, str) or not resolved_project.strip():
+        resolved_project = _extract_project(payload, default_project=default_project)
+    else:
+        resolved_project = resolved_project.strip()
+
+    resolved_issue_key = issue_key
+    if not isinstance(resolved_issue_key, str) or not resolved_issue_key.strip():
+        resolved_issue_key = _extract_issue_key(payload)
+    else:
+        resolved_issue_key = resolved_issue_key.strip()
 
     return WebhookLifecycleContext(
         event=event,
-        action=action,
-        project=_extract_project(payload, default_project=default_project),
-        issue_key=_extract_issue_key(payload),
+        action=resolved_action,
+        project=resolved_project,
+        issue_key=resolved_issue_key,
         delivery_id=normalized_delivery,
         workflow_id=resolved_workflow_id,
     )

--- a/src/ace/webhooks/pubsub_queue.py
+++ b/src/ace/webhooks/pubsub_queue.py
@@ -19,6 +19,10 @@ class QueuedWebhookEvent:
     payload: dict[str, Any]
     delivery: str | None
     workflow_id: str | None = None
+    issue_key: str | None = None
+    project: str | None = None
+    action: str | None = None
+    queued_at: str | None = None
     message_id: str | None = None
 
 
@@ -49,17 +53,42 @@ class PubSubWebhookQueue:
         payload: dict[str, Any],
         delivery: str | None,
         workflow_id: str | None = None,
+        issue_key: str | None = None,
+        project: str | None = None,
+        action: str | None = None,
+        queued_at: str | None = None,
     ) -> str:
+        correlation = {
+            "delivery_id": delivery,
+            "workflow_id": workflow_id,
+            "issue_key": issue_key,
+            "project": project,
+            "action": action,
+        }
         envelope = {
+            "schema_version": "2",
             "event": event,
             "payload": payload,
             "delivery": delivery,
             "workflow_id": workflow_id,
+            "queued_at": queued_at,
+            "correlation": correlation,
         }
         body = json.dumps(envelope, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
         attrs = {"event": event}
         if delivery:
             attrs["delivery"] = delivery
+            attrs["delivery_id"] = delivery
+        if workflow_id:
+            attrs["workflow_id"] = workflow_id
+        if issue_key:
+            attrs["issue_key"] = issue_key
+        if project:
+            attrs["project"] = project
+        if action:
+            attrs["action"] = action
+        if queued_at:
+            attrs["queued_at"] = queued_at
         publish_future = self._publisher.publish(self._topic_path, body, **attrs)
         return await asyncio.to_thread(lambda: str(publish_future.result(timeout=30)))
 
@@ -86,18 +115,57 @@ def decode_pubsub_push(body: dict[str, Any]) -> QueuedWebhookEvent:
 
     event = envelope.get("event")
     payload = envelope.get("payload")
-    delivery = envelope.get("delivery")
-    workflow_id = envelope.get("workflow_id")
+    attrs = message.get("attributes")
+    if attrs is None:
+        attrs = {}
+    if not isinstance(attrs, dict):
+        raise ValueError("❌ ERROR: invalid_pubsub_push: message.attributes must be an object")
+    for key, value in attrs.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError(
+                "❌ ERROR: invalid_pubsub_push: message.attributes must be string keys and values"
+            )
+
+    correlation = envelope.get("correlation")
+    if correlation is None:
+        correlation = {}
+    if not isinstance(correlation, dict):
+        raise ValueError("❌ ERROR: invalid_pubsub_push: correlation must be an object")
+
+    delivery = _first_string(
+        envelope.get("delivery"),
+        correlation.get("delivery_id"),
+        attrs.get("delivery_id"),
+        attrs.get("delivery"),
+    )
+    workflow_id = _first_string(
+        envelope.get("workflow_id"),
+        correlation.get("workflow_id"),
+        attrs.get("workflow_id"),
+    )
+    issue_key = _first_string(
+        correlation.get("issue_key"),
+        attrs.get("issue_key"),
+    )
+    project = _first_string(
+        correlation.get("project"),
+        attrs.get("project"),
+    )
+    action = _first_string(
+        correlation.get("action"),
+        payload.get("action") if isinstance(payload, dict) else None,
+        attrs.get("action"),
+    )
+    queued_at = _first_string(
+        envelope.get("queued_at"),
+        attrs.get("queued_at"),
+    )
     message_id = message.get("messageId")
 
     if not isinstance(event, str) or not event:
         raise ValueError("❌ ERROR: invalid_pubsub_push: missing event")
     if not isinstance(payload, dict):
         raise ValueError("❌ ERROR: invalid_pubsub_push: payload must be an object")
-    if delivery is not None and not isinstance(delivery, str):
-        raise ValueError("❌ ERROR: invalid_pubsub_push: delivery must be string or null")
-    if workflow_id is not None and not isinstance(workflow_id, str):
-        raise ValueError("❌ ERROR: invalid_pubsub_push: workflow_id must be string or null")
     if message_id is not None and not isinstance(message_id, str):
         raise ValueError("❌ ERROR: invalid_pubsub_push: messageId must be string")
 
@@ -106,5 +174,21 @@ def decode_pubsub_push(body: dict[str, Any]) -> QueuedWebhookEvent:
         payload=payload,
         delivery=delivery,
         workflow_id=workflow_id,
+        issue_key=issue_key,
+        project=project,
+        action=action,
+        queued_at=queued_at,
         message_id=message_id,
     )
+
+
+def _first_string(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if value is None:
+            continue
+        raise ValueError(
+            "❌ ERROR: invalid_pubsub_push: expected string value in correlation fields"
+        )
+    return None

--- a/tests/test_pubsub_queue.py
+++ b/tests/test_pubsub_queue.py
@@ -1,0 +1,121 @@
+import base64
+import json
+
+import pytest
+
+from ace.webhooks.pubsub_queue import PubSubWebhookQueue, decode_pubsub_push
+
+
+class _StubPublishFuture:
+    def __init__(self, message_id: str):
+        self._message_id = message_id
+
+    def result(self, timeout: int | None = None) -> str:
+        return self._message_id
+
+
+class _StubPublisher:
+    def __init__(self):
+        self.calls = []
+
+    def publish(self, topic_path: str, body: bytes, **attrs):
+        self.calls.append({"topic_path": topic_path, "body": body, "attrs": attrs})
+        return _StubPublishFuture("pubsub-123")
+
+
+@pytest.mark.asyncio
+async def test_publish_includes_correlation_payload_and_attributes():
+    publisher = _StubPublisher()
+    queue = PubSubWebhookQueue(
+        publisher=publisher,
+        topic_path="projects/test/topics/appforge-webhooks",
+    )
+
+    message_id = await queue.publish(
+        event="issue_comment",
+        payload={"action": "created"},
+        delivery="delivery-1",
+        workflow_id="wf-1",
+        issue_key="Day-in-the-Country-LLC/digido#34",
+        project="Appforge",
+        action="created",
+        queued_at="2026-02-12T18:00:00+00:00",
+    )
+
+    assert message_id == "pubsub-123"
+    assert len(publisher.calls) == 1
+    call = publisher.calls[0]
+    assert call["attrs"]["delivery_id"] == "delivery-1"
+    assert call["attrs"]["workflow_id"] == "wf-1"
+    assert call["attrs"]["issue_key"] == "Day-in-the-Country-LLC/digido#34"
+    assert call["attrs"]["project"] == "Appforge"
+    assert call["attrs"]["queued_at"] == "2026-02-12T18:00:00+00:00"
+
+    envelope = json.loads(call["body"].decode("utf-8"))
+    assert envelope["schema_version"] == "2"
+    assert envelope["queued_at"] == "2026-02-12T18:00:00+00:00"
+    assert envelope["correlation"]["delivery_id"] == "delivery-1"
+    assert envelope["correlation"]["workflow_id"] == "wf-1"
+    assert envelope["correlation"]["issue_key"] == "Day-in-the-Country-LLC/digido#34"
+    assert envelope["correlation"]["project"] == "Appforge"
+    assert envelope["correlation"]["action"] == "created"
+
+
+def test_decode_pubsub_push_reads_correlation_fields():
+    envelope = {
+        "event": "projects_v2_item",
+        "payload": {"action": "edited"},
+        "delivery": "delivery-2",
+        "workflow_id": "wf-2",
+        "queued_at": "2026-02-12T18:00:00+00:00",
+        "correlation": {
+            "issue_key": "Day-in-the-Country-LLC/digido#99",
+            "project": "Appforge",
+            "action": "edited",
+        },
+    }
+    body = {
+        "message": {
+            "messageId": "1234",
+            "data": base64.b64encode(json.dumps(envelope).encode("utf-8")).decode("utf-8"),
+            "attributes": {
+                "delivery_id": "delivery-2",
+                "workflow_id": "wf-2",
+                "issue_key": "Day-in-the-Country-LLC/digido#99",
+                "project": "Appforge",
+                "queued_at": "2026-02-12T18:00:00+00:00",
+            },
+        }
+    }
+
+    queued = decode_pubsub_push(body)
+    assert queued.message_id == "1234"
+    assert queued.delivery == "delivery-2"
+    assert queued.workflow_id == "wf-2"
+    assert queued.issue_key == "Day-in-the-Country-LLC/digido#99"
+    assert queued.project == "Appforge"
+    assert queued.action == "edited"
+    assert queued.queued_at == "2026-02-12T18:00:00+00:00"
+
+
+def test_decode_pubsub_push_accepts_legacy_envelope():
+    envelope = {
+        "event": "issue_comment",
+        "payload": {},
+        "delivery": "delivery-legacy",
+        "workflow_id": "wf-legacy",
+    }
+    body = {
+        "message": {
+            "messageId": "legacy-1",
+            "data": base64.b64encode(json.dumps(envelope).encode("utf-8")).decode("utf-8"),
+        }
+    }
+
+    queued = decode_pubsub_push(body)
+    assert queued.message_id == "legacy-1"
+    assert queued.delivery == "delivery-legacy"
+    assert queued.workflow_id == "wf-legacy"
+    assert queued.issue_key is None
+    assert queued.project is None
+    assert queued.queued_at is None

--- a/tests/test_slack_notifications.py
+++ b/tests/test_slack_notifications.py
@@ -49,13 +49,28 @@ def test_webhook_listener_enqueues_pubsub(monkeypatch):
     published = []
 
     class StubQueue:
-        async def publish(self, *, event, payload, delivery, workflow_id=None):
+        async def publish(
+            self,
+            *,
+            event,
+            payload,
+            delivery,
+            workflow_id=None,
+            issue_key=None,
+            project=None,
+            action=None,
+            queued_at=None,
+        ):
             published.append(
                 {
                     "event": event,
                     "payload": payload,
                     "delivery": delivery,
                     "workflow_id": workflow_id,
+                    "issue_key": issue_key,
+                    "project": project,
+                    "action": action,
+                    "queued_at": queued_at,
                 }
             )
             return "msg-123"
@@ -69,6 +84,7 @@ def test_webhook_listener_enqueues_pubsub(monkeypatch):
         (),
         {
             "webhook_service_role": "listener",
+            "github_project_name": "Appforge",
             "debug": False,
             "slack_bot_token": "",
             "slack_channel_id": "",
@@ -77,7 +93,13 @@ def test_webhook_listener_enqueues_pubsub(monkeypatch):
 
     secret = "test-secret"
     os.environ["GITHUB_WEBHOOK_SECRET"] = secret
-    body = b'{"hello":"world"}'
+    body = json.dumps(
+        {
+            "action": "created",
+            "issue": {"number": 9},
+            "repository": {"name": "digido", "owner": {"login": "Day-in-the-Country-LLC"}},
+        }
+    ).encode("utf-8")
     mac = hmac.new(secret.encode("utf-8"), msg=body, digestmod=hashlib.sha256)
     sig = f"sha256={mac.hexdigest()}"
 
@@ -100,7 +122,11 @@ def test_webhook_listener_enqueues_pubsub(monkeypatch):
         assert published[0]["event"] == "issue_comment"
         assert published[0]["delivery"] == "delivery-1"
         assert published[0]["workflow_id"] == "delivery-1"
-        assert published[0]["payload"] == {"hello": "world"}
+        assert published[0]["issue_key"] == "Day-in-the-Country-LLC/digido#9"
+        assert published[0]["project"] == "Appforge"
+        assert published[0]["action"] == "created"
+        assert isinstance(published[0]["queued_at"], str)
+        assert published[0]["payload"]["issue"]["number"] == 9
     finally:
         webhook_app._queue = old_queue
         webhook_app._settings = old_settings
@@ -148,10 +174,25 @@ def test_webhook_worker_success_sends_slack(monkeypatch):
                     {
                         "event": "issue_comment",
                         "delivery": "delivery-1",
+                        "queued_at": "2026-02-12T18:00:00+00:00",
+                        "correlation": {
+                            "delivery_id": "delivery-1",
+                            "workflow_id": "delivery-1",
+                            "issue_key": "Day-in-the-Country-LLC/digido#123",
+                            "project": "Appforge",
+                            "action": "created",
+                        },
                         "payload": {},
                     }
                 ).encode("utf-8")
             ).decode("utf-8"),
+            "attributes": {
+                "delivery_id": "delivery-1",
+                "workflow_id": "delivery-1",
+                "issue_key": "Day-in-the-Country-LLC/digido#123",
+                "project": "Appforge",
+                "action": "created",
+            },
         }
     }
 
@@ -163,6 +204,9 @@ def test_webhook_worker_success_sends_slack(monkeypatch):
         assert "Webhook processed" in posted[0]
         assert "event=issue_comment" in posted[0]
         assert resp.json()["workflow_id"] == "delivery-1"
+        assert resp.json()["pubsub_message_id"] == "1234"
+        assert resp.json()["queued_at"] == "2026-02-12T18:00:00+00:00"
+        assert resp.json()["queue_delay_ms"] is not None
         assert resp.json()["resolution"] == "success"
     finally:
         webhook_app._handler = old_handler
@@ -189,7 +233,18 @@ def test_webhook_listener_lifecycle_logs(monkeypatch):
             events.append({"event_name": event_name, "fields": merged})
 
     class StubQueue:
-        async def publish(self, *, event, payload, delivery, workflow_id=None):
+        async def publish(
+            self,
+            *,
+            event,
+            payload,
+            delivery,
+            workflow_id=None,
+            issue_key=None,
+            project=None,
+            action=None,
+            queued_at=None,
+        ):
             return "msg-xyz"
 
     old_logger = webhook_app.logger
@@ -243,6 +298,8 @@ def test_webhook_listener_lifecycle_logs(monkeypatch):
             assert fields["workflow_id"] == "delivery-42"
             assert fields["issue_key"] == "Day-in-the-Country-LLC/digido#34"
             assert fields["project"] == "Appforge"
+        assert lifecycle[1]["fields"]["pubsub_message_id"] == "msg-xyz"
+        assert isinstance(lifecycle[1]["fields"]["queued_at"], str)
     finally:
         webhook_app.logger = old_logger
         webhook_app._queue = old_queue
@@ -299,6 +356,14 @@ def test_webhook_worker_lifecycle_logs_blocked(monkeypatch):
                         "event": "projects_v2_item",
                         "delivery": "delivery-11",
                         "workflow_id": "wf-11",
+                        "queued_at": "2026-02-12T18:00:00+00:00",
+                        "correlation": {
+                            "delivery_id": "delivery-11",
+                            "workflow_id": "wf-11",
+                            "issue_key": "Day-in-the-Country-LLC/digido#34",
+                            "project": "Appforge",
+                            "action": "edited",
+                        },
                         "payload": {
                             "action": "edited",
                             "issue": {"number": 34},
@@ -318,6 +383,8 @@ def test_webhook_worker_lifecycle_logs_blocked(monkeypatch):
         resp = client.post("/internal/pubsub/worker", json=envelope)
         assert resp.status_code == 200
         assert resp.json()["resolution"] == "blocked"
+        assert resp.json()["pubsub_message_id"] == "1234"
+        assert resp.json()["queue_delay_ms"] is not None
 
         lifecycle = [e for e in events if e["event_name"] == "webhook_lifecycle"]
         assert [e["fields"]["stage"] for e in lifecycle] == [
@@ -332,8 +399,87 @@ def test_webhook_worker_lifecycle_logs_blocked(monkeypatch):
             assert fields["workflow_id"] == "wf-11"
             assert fields["delivery_id"] == "delivery-11"
             assert fields["issue_key"] == "Day-in-the-Country-LLC/digido#34"
+        assert lifecycle[0]["fields"]["pubsub_message_id"] == "1234"
+        assert lifecycle[0]["fields"]["queue_delay_ms"] is not None
 
         assert lifecycle[-1]["fields"]["resolution"] == "blocked"
+    finally:
+        webhook_app.logger = old_logger
+        webhook_app._handler = old_handler
+        webhook_app._notifier = old_notifier
+        webhook_app._settings = old_settings
+
+
+def test_webhook_worker_failure_logs_resolution(monkeypatch):
+    from ace.webhooks import app as webhook_app
+
+    events = []
+
+    class StubLogger:
+        def __init__(self):
+            self._bound = {}
+
+        def bind(self, **kwargs):
+            self._bound.update(kwargs)
+            return self
+
+        def info(self, event_name, **fields):
+            merged = dict(self._bound)
+            merged.update(fields)
+            events.append({"event_name": event_name, "fields": merged})
+
+    class StubHandler:
+        async def handle(self, event, payload, delivery):
+            raise RuntimeError("spawn_failed")
+
+    old_logger = webhook_app.logger
+    old_handler = webhook_app._handler
+    old_notifier = webhook_app._notifier
+    old_settings = webhook_app._settings
+    webhook_app.logger = StubLogger()
+    webhook_app._handler = StubHandler()
+    webhook_app._notifier = None
+    webhook_app._settings = type(
+        "SettingsStub",
+        (),
+        {
+            "webhook_service_role": "worker",
+            "github_project_name": "Appforge",
+            "debug": False,
+            "slack_bot_token": "",
+            "slack_channel_id": "",
+        },
+    )()
+
+    envelope = {
+        "message": {
+            "messageId": "1234",
+            "data": base64.b64encode(
+                json.dumps(
+                    {
+                        "event": "issue_comment",
+                        "delivery": "delivery-1",
+                        "queued_at": "2026-02-12T18:00:00+00:00",
+                        "correlation": {
+                            "delivery_id": "delivery-1",
+                            "workflow_id": "wf-1",
+                            "issue_key": "Day-in-the-Country-LLC/digido#34",
+                            "project": "Appforge",
+                        },
+                        "payload": {"issue": {"number": 34}},
+                    }
+                ).encode("utf-8")
+            ).decode("utf-8"),
+        }
+    }
+
+    try:
+        client = TestClient(webhook_app.app, raise_server_exceptions=False)
+        resp = client.post("/internal/pubsub/worker", json=envelope)
+        assert resp.status_code == 500
+        lifecycle = [e for e in events if e["event_name"] == "webhook_lifecycle"]
+        assert lifecycle[-1]["fields"]["stage"] == "final_resolution"
+        assert lifecycle[-1]["fields"]["resolution"] == "failure"
     finally:
         webhook_app.logger = old_logger
         webhook_app._handler = old_handler

--- a/tests/test_webhook_lifecycle.py
+++ b/tests/test_webhook_lifecycle.py
@@ -40,6 +40,20 @@ def test_build_lifecycle_context_uses_default_project_and_generated_workflow_id(
     assert context.workflow_id.startswith("wf-")
 
 
+def test_build_lifecycle_context_uses_explicit_correlation_overrides():
+    context = build_lifecycle_context(
+        event="projects_v2_item",
+        payload={},
+        delivery="delivery-1",
+        project="Appforge",
+        issue_key="Day-in-the-Country-LLC/digido#34",
+        action="edited",
+    )
+    assert context.project == "Appforge"
+    assert context.issue_key == "Day-in-the-Country-LLC/digido#34"
+    assert context.action == "edited"
+
+
 def test_normalize_result_resolution():
     assert normalize_result_resolution({"status": "blocked"}) == RESOLUTION_BLOCKED
     assert normalize_result_resolution({"status": "failed"}) == RESOLUTION_FAILURE


### PR DESCRIPTION
## Summary
- propagate correlation data (`issue_key`, `project`, `delivery_id`, `workflow_id`, `action`) through Pub/Sub envelope + message attributes
- extend decoded queue event with correlation fields and `queued_at`
- add queue timing visibility by logging `queued_at`, `dequeued_at`, and computed `queue_delay_ms`
- include `pubsub_message_id` consistently in worker lifecycle logs and worker response payload
- ensure worker context can use correlation overrides from Pub/Sub even when webhook payload is sparse
- add tests for publish/decode correlation schema, worker failure resolution logging, and lifecycle field propagation
- document the v2 Pub/Sub correlation schema and required worker log fields

## Testing
- `uv run ruff format src tests docs`
- `uv run ruff check src tests`
- `uv run pytest`

Closes #5
