### PR TITLE
Implement PR review domain models and config foundations

### DIFF
--- a/src/ace/config/settings.py
+++ b/src/ace/config/settings.py
@@ -63,6 +63,25 @@ class Settings(BaseSettings):
         "high",
     ).strip().lower()
 
+    # PR review gate
+    pr_review_enabled: bool = os.getenv("PR_REVIEW_ENABLED", "true").lower() == "true"
+    pr_review_codex_model: str = os.getenv("PR_REVIEW_CODEX_MODEL", "gpt-5.2-codex")
+    pr_review_claude_model: str = os.getenv("PR_REVIEW_CLAUDE_MODEL", "claude-opus-4-6")
+    pr_review_codex_max_tokens: int = int(os.getenv("PR_REVIEW_CODEX_MAX_TOKENS", "4000"))
+    pr_review_claude_max_tokens: int = int(os.getenv("PR_REVIEW_CLAUDE_MAX_TOKENS", "4000"))
+    pr_review_codex_reasoning_effort: str = os.getenv(
+        "PR_REVIEW_CODEX_REASONING_EFFORT",
+        "high",
+    ).strip().lower()
+    pr_review_max_rounds: int = int(os.getenv("PR_REVIEW_MAX_ROUNDS", "2"))
+    pr_review_consensus_mode: str = os.getenv("PR_REVIEW_CONSENSUS_MODE", "both_approve")
+    pr_review_target_branch: str = os.getenv("PR_REVIEW_TARGET_BRANCH", "qa")
+    pr_review_require_checks: bool = (
+        os.getenv("PR_REVIEW_REQUIRE_CHECKS", "true").lower() == "true"
+    )
+    pr_review_diff_max_chars: int = int(os.getenv("PR_REVIEW_DIFF_MAX_CHARS", "100000"))
+    pr_review_allowed_repos: str = os.getenv("PR_REVIEW_ALLOWED_REPOS", "")
+
     # GCP
     gcp_project_id: str = os.getenv("GCP_PROJECT_ID", "")
     gcp_credentials_path: str = os.getenv(

--- a/src/ace/pr_review/__init__.py
+++ b/src/ace/pr_review/__init__.py
@@ -1,0 +1,19 @@
+"""Domain models for collaborative PR review flows."""
+
+from .models import (
+    PRReviewSession,
+    PRReviewStatus,
+    ReviewConfidence,
+    ReviewFinding,
+    ReviewVerdict,
+    ReviewerVerdict,
+)
+
+__all__ = [
+    "PRReviewSession",
+    "PRReviewStatus",
+    "ReviewConfidence",
+    "ReviewFinding",
+    "ReviewVerdict",
+    "ReviewerVerdict",
+]

--- a/src/ace/pr_review/models.py
+++ b/src/ace/pr_review/models.py
@@ -1,0 +1,224 @@
+"""Pydantic-free dataclass domain models for collaborative PR reviews."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+
+class ReviewVerdict(str, Enum):
+    """High-level LLM verdict for a review payload."""
+
+    APPROVE = "approve"
+    REQUEST_CHANGES = "request_changes"
+    COMMENT = "comment"
+
+
+class ReviewConfidence(str, Enum):
+    """Confidence level associated with a review verdict."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class PRReviewStatus(str, Enum):
+    """Lifecycle states used by PR review sessions."""
+
+    IN_PROGRESS = "in_progress"
+    CONSENSUS_APPROVE = "consensus_approve"
+    CONSENSUS_REJECT = "consensus_reject"
+    ERROR = "error"
+
+
+def _to_enum(enum_cls: type[Enum], value: Any, field_name: str) -> Enum:
+    """Parse and validate enum payload values with explicit fail-fast errors."""
+    if isinstance(value, enum_cls):
+        return value
+    try:
+        return enum_cls(value)
+    except Exception as exc:
+        raise ValueError(
+            f"❌ ERROR: {field_name} must be one of "
+            f"{[member.value for member in enum_cls]} (got {value!r})"
+        ) from exc
+
+
+def _iso_to_utc_datetime(value: Any, field_name: str) -> datetime:
+    """Parse timestamps from ISO-8601 strings with fail-fast validation."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"❌ ERROR: {field_name} must be an ISO-8601 string")
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"❌ ERROR: {field_name} must be an ISO-8601 string") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+@dataclass(frozen=True)
+class ReviewFinding:
+    """Single finding produced by a model during PR review."""
+
+    file_path: str
+    line_start: int | None
+    line_end: int | None
+    severity: str
+    category: str
+    description: str
+    suggested_fix: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe data."""
+        return {
+            "file_path": self.file_path,
+            "line_start": self.line_start,
+            "line_end": self.line_end,
+            "severity": self.severity,
+            "category": self.category,
+            "description": self.description,
+            "suggested_fix": self.suggested_fix,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ReviewFinding":
+        """Deserialize from a validated payload."""
+        return cls(
+            file_path=str(payload["file_path"]),
+            line_start=payload.get("line_start"),
+            line_end=payload.get("line_end"),
+            severity=str(payload["severity"]),
+            category=str(payload["category"]),
+            description=str(payload["description"]),
+            suggested_fix=payload.get("suggested_fix"),
+        )
+
+
+@dataclass
+class ReviewerVerdict:
+    """Verdict and findings produced by a single model reviewer."""
+
+    reviewer_model: str
+    verdict: ReviewVerdict
+    confidence: ReviewConfidence
+    blocking_findings: list[ReviewFinding] = field(default_factory=list)
+    non_blocking_findings: list[ReviewFinding] = field(default_factory=list)
+    suggested_comments: list[str] = field(default_factory=list)
+    reasoning: str = ""
+    round_number: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe data."""
+        return {
+            "reviewer_model": self.reviewer_model,
+            "verdict": self.verdict.value,
+            "confidence": self.confidence.value,
+            "blocking_findings": [finding.to_dict() for finding in self.blocking_findings],
+            "non_blocking_findings": [finding.to_dict() for finding in self.non_blocking_findings],
+            "suggested_comments": list(self.suggested_comments),
+            "reasoning": self.reasoning,
+            "round_number": self.round_number,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ReviewerVerdict":
+        """Deserialize from a validated payload."""
+        return cls(
+            reviewer_model=str(payload["reviewer_model"]),
+            verdict=_to_enum(ReviewVerdict, payload["verdict"], "verdict"),
+            confidence=_to_enum(ReviewConfidence, payload["confidence"], "confidence"),
+            blocking_findings=[
+                ReviewFinding.from_dict(finding)
+                for finding in payload.get("blocking_findings", [])
+            ],
+            non_blocking_findings=[
+                ReviewFinding.from_dict(finding)
+                for finding in payload.get("non_blocking_findings", [])
+            ],
+            suggested_comments=list(payload.get("suggested_comments", [])),
+            reasoning=str(payload.get("reasoning", "")),
+            round_number=int(payload.get("round_number", 1)),
+        )
+
+
+@dataclass
+class PRReviewSession:
+    """Aggregate state for one PR review collaboration session."""
+
+    session_id: str
+    pr_number: int
+    repo_owner: str
+    repo_name: str
+    head_sha: str
+    base_branch: str
+    created_at: datetime
+    updated_at: datetime
+    status: PRReviewStatus
+    rounds: list[dict[str, ReviewerVerdict]] = field(default_factory=list)
+    final_codex_verdict: ReviewerVerdict | None = None
+    final_claude_verdict: ReviewerVerdict | None = None
+    merged: bool = False
+    error_message: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe data."""
+        return {
+            "session_id": self.session_id,
+            "pr_number": self.pr_number,
+            "repo_owner": self.repo_owner,
+            "repo_name": self.repo_name,
+            "head_sha": self.head_sha,
+            "base_branch": self.base_branch,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "status": self.status.value,
+            "rounds": [
+                {reviewer: verdict.to_dict() for reviewer, verdict in item.items()}
+                for item in self.rounds
+            ],
+            "final_codex_verdict": (
+                self.final_codex_verdict.to_dict() if self.final_codex_verdict else None
+            ),
+            "final_claude_verdict": (
+                self.final_claude_verdict.to_dict() if self.final_claude_verdict else None
+            ),
+            "merged": self.merged,
+            "error_message": self.error_message,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PRReviewSession":
+        """Deserialize from a validated payload."""
+        return cls(
+            session_id=str(payload["session_id"]),
+            pr_number=int(payload["pr_number"]),
+            repo_owner=str(payload["repo_owner"]),
+            repo_name=str(payload["repo_name"]),
+            head_sha=str(payload["head_sha"]),
+            base_branch=str(payload["base_branch"]),
+            created_at=_iso_to_utc_datetime(payload["created_at"], "created_at"),
+            updated_at=_iso_to_utc_datetime(payload["updated_at"], "updated_at"),
+            status=_to_enum(PRReviewStatus, payload["status"], "status"),
+            rounds=[
+                {
+                    str(reviewer): ReviewerVerdict.from_dict(verdict)
+                    for reviewer, verdict in item.items()
+                }
+                for item in payload.get("rounds", [])
+            ],
+            final_codex_verdict=(
+                ReviewerVerdict.from_dict(payload["final_codex_verdict"])
+                if payload.get("final_codex_verdict")
+                else None
+            ),
+            final_claude_verdict=(
+                ReviewerVerdict.from_dict(payload["final_claude_verdict"])
+                if payload.get("final_claude_verdict")
+                else None
+            ),
+            merged=bool(payload.get("merged", False)),
+            error_message=payload.get("error_message"),
+        )

--- a/src/ace/webhooks/lifecycle.py
+++ b/src/ace/webhooks/lifecycle.py
@@ -24,6 +24,17 @@ STAGE_PLANNING_DONE = "planning_done"
 STAGE_PLANNING_FAILED = "planning_failed"
 STAGE_PLANNING_ISSUE_WRITER = "planning_issue_writer"
 
+# PR review stages
+STAGE_PR_REVIEW_STARTED = "pr_review_started"
+STAGE_PR_REVIEW_CODEX_INITIAL = "pr_review_codex_initial"
+STAGE_PR_REVIEW_CLAUDE_INITIAL = "pr_review_claude_initial"
+STAGE_PR_REVIEW_CROSS_FEEDBACK = "pr_review_cross_feedback"
+STAGE_PR_REVIEW_CONSENSUS = "pr_review_consensus"
+STAGE_PR_REVIEW_APPROVAL_SUBMITTED = "pr_review_approval_submitted"
+STAGE_PR_REVIEW_MERGED = "pr_review_merged"
+STAGE_PR_REVIEW_REJECTED = "pr_review_rejected"
+STAGE_PR_REVIEW_ERROR = "pr_review_error"
+
 RESOLUTION_SUCCESS = "success"
 RESOLUTION_BLOCKED = "blocked"
 RESOLUTION_FAILURE = "failure"

--- a/tests/test_pr_review_models.py
+++ b/tests/test_pr_review_models.py
@@ -1,0 +1,81 @@
+from datetime import UTC, datetime
+
+from ace.pr_review import (
+    PRReviewSession,
+    PRReviewStatus,
+    ReviewConfidence,
+    ReviewFinding,
+    ReviewVerdict,
+    ReviewerVerdict,
+)
+
+
+def test_review_finding_roundtrip():
+    finding = ReviewFinding(
+        file_path="src/ace/webhooks/app.py",
+        line_start=10,
+        line_end=20,
+        severity="blocking",
+        category="security",
+        description="Potential injection path detected",
+        suggested_fix="Use parameterized query",
+    )
+    payload = finding.to_dict()
+    recovered = ReviewFinding.from_dict(payload)
+    assert recovered == finding
+
+
+def test_reviewer_verdict_roundtrip():
+    verdict = ReviewerVerdict(
+        reviewer_model="gpt-5.2-codex",
+        verdict=ReviewVerdict.APPROVE,
+        confidence=ReviewConfidence.HIGH,
+        blocking_findings=[
+            ReviewFinding(
+                file_path="src/ace/app.py",
+                line_start=1,
+                line_end=2,
+                severity="suggestion",
+                category="style",
+                description="Spacing issue",
+                suggested_fix="Run formatter",
+            ),
+        ],
+        suggested_comments=["Looks good"],
+        reasoning="Tests cover edge cases",
+        round_number=1,
+    )
+    payload = verdict.to_dict()
+    recovered = ReviewerVerdict.from_dict(payload)
+    assert payload["verdict"] == "approve"
+    assert payload["confidence"] == "high"
+    assert recovered == verdict
+
+
+def test_pr_review_session_roundtrip():
+    codex_verdict = ReviewerVerdict(
+        reviewer_model="gpt-5.2-codex",
+        verdict=ReviewVerdict.COMMENT,
+        confidence=ReviewConfidence.MEDIUM,
+    )
+    session = PRReviewSession(
+        session_id="session-1",
+        pr_number=101,
+        repo_owner="acme",
+        repo_name="widget-api",
+        head_sha="abc123",
+        base_branch="qa",
+        created_at=datetime(2026, 2, 18, 10, 5, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 2, 18, 10, 6, 0, tzinfo=UTC),
+        status=PRReviewStatus.IN_PROGRESS,
+        rounds=[{"gpt-5.2-codex": codex_verdict}],
+        final_codex_verdict=codex_verdict,
+        final_claude_verdict=None,
+        merged=False,
+        error_message=None,
+    )
+    payload = session.to_dict()
+    recovered = PRReviewSession.from_dict(payload)
+    assert payload["status"] == "in_progress"
+    assert payload["rounds"][0]["gpt-5.2-codex"]["verdict"] == "comment"
+    assert recovered == session


### PR DESCRIPTION
Implements Issue #13 foundation work under the collaborative PR-review epic.

- Add PR review domain dataclasses and enums in `src/ace/pr_review/models.py`
- Add package exports in `src/ace/pr_review/__init__.py`
- Add PR review gate settings to `src/ace/config/settings.py`
- Add PR review lifecycle stage constants in `src/ace/webhooks/lifecycle.py`
- Add serialization/deserialization tests in `tests/test_pr_review_models.py`

Closes #13