### PR TITLE
feat: add session and review lifecycle telemetry

### DIFF
--- a/src/ace/orchestration/graph.py
+++ b/src/ace/orchestration/graph.py
@@ -20,6 +20,15 @@ from ace.github.api_client import GitHubAPIClient
 from ace.github.status_manager import StatusManager
 from ace.issue_tracking import build_work_item_enricher, build_work_item_tracker
 from ace.logging_utils import log_key_event
+from ace.webhooks.lifecycle import (
+    STAGE_SESSION_RESUME,
+    STAGE_SESSION_START,
+    STAGE_SESSION_STALL,
+    STAGE_SESSION_TURN_COMPLETE,
+    STAGE_SESSION_TURN_START,
+    build_session_lifecycle_context,
+    log_session_lifecycle_event,
+)
 from ace.notifications.slack_client import SlackNotifier, format_completion_message
 from ace.orchestration.session_runtime import (
     SessionContext,
@@ -151,6 +160,7 @@ async def run_agent(state: WorkerState) -> WorkerState:
         "repo_owner": state.metadata.get("repo_owner", "unknown"),
         "issue_number": state.issue_number,
         "labels": state.issue.labels,
+        "source": state.metadata.get("source", "worker"),
     }
 
     repo_owner = state.metadata.get("repo_owner") or state.issue.repo_owner
@@ -199,6 +209,33 @@ async def run_agent(state: WorkerState) -> WorkerState:
     run_context["done_filename"] = done_filename
     run_context["session_turn"] = state.session_turn
     run_context["retry_count"] = state.retry_count
+    run_context["workflow_id"] = state.metadata.get("workflow_id", state.session_id)
+    session_workflow_id = run_context["workflow_id"]
+    state.metadata["source"] = run_context["source"]
+    session_issue_key = f"{state.issue.repo_owner}/{state.issue.repo_name}#{state.issue.number}"
+    session_lifecycle_context = build_session_lifecycle_context(
+        session_id=state.session_id,
+        turn_number=state.session_turn,
+        workflow_id=session_workflow_id,
+        source=run_context["source"],
+        issue_key=session_issue_key,
+        project=run_context["repo_name"],
+    )
+    log_session_lifecycle_event(logger, STAGE_SESSION_START, session_lifecycle_context)
+    if state.previous_output:
+        log_session_lifecycle_event(
+            logger,
+            STAGE_SESSION_RESUME,
+            session_lifecycle_context,
+            reason="previous_output_detected",
+        )
+    log_session_lifecycle_event(
+        logger,
+        STAGE_SESSION_TURN_START,
+        session_lifecycle_context,
+        labels=state.issue.labels,
+    )
+
     previous_output = state.previous_output or None
     if state.retry_count:
         turn_type = SessionTurnType.RETRY
@@ -276,9 +313,18 @@ async def run_agent(state: WorkerState) -> WorkerState:
     result = await runner.run_turn(session_context, instructions, previous_result=previous_result)
     state.agent_result = result
 
+    requested_input = False
     if result.status == AgentStatus.FAILED:
         state.error = result.error or result.output or "agent_failed"
         if await runner.request_input(result):
+            requested_input = True
+            log_session_lifecycle_event(
+                logger,
+                STAGE_SESSION_STALL,
+                session_lifecycle_context,
+                reason="runner_request_input",
+                error=state.error,
+            )
             state.previous_output = state.previous_output or result.output or result.error or ""
             state.session_turn += 1
             state.retry_count += 1
@@ -289,6 +335,15 @@ async def run_agent(state: WorkerState) -> WorkerState:
     else:
         await runner.stop(session_context, reason="completed")
 
+    log_session_lifecycle_event(
+        logger,
+        STAGE_SESSION_TURN_COMPLETE,
+        session_lifecycle_context,
+        turn_result=result.status.value,
+        requested_input=requested_input,
+        output_length=len(result.output),
+        error=state.error,
+    )
     logger.info(
         "agent_execution_complete",
         issue=state.issue_number,

--- a/src/ace/webhooks/app.py
+++ b/src/ace/webhooks/app.py
@@ -172,6 +172,7 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
             payload=payload,
             delivery=delivery,
             default_project=getattr(settings, "github_project_name", None),
+            source="github",
             repo_gcp_mapping=_get_repo_gcp_mapping(),
         )
     except Exception as exc:
@@ -184,6 +185,7 @@ async def github_webhooks(request: Request) -> dict[str, Any]:
             event=event,
             payload=payload,
             delivery=delivery,
+            source=context.source,
             workflow_id=context.workflow_id,
             issue_key=context.issue_key,
             project=context.project,
@@ -243,6 +245,7 @@ async def pubsub_worker(request: Request) -> dict[str, Any]:
             event=queued.event,
             payload=queued.payload,
             delivery=queued.delivery,
+            source=queued.source,
             workflow_id=queued.workflow_id,
             default_project=getattr(settings, "github_project_name", None),
             project=queued.project,

--- a/src/ace/webhooks/handlers.py
+++ b/src/ace/webhooks/handlers.py
@@ -27,6 +27,8 @@ from ace.webhooks.lifecycle import (
     STAGE_PR_REVIEW_ERROR,
     STAGE_PR_REVIEW_SKIPPED,
     STAGE_PR_REVIEW_STARTED,
+    build_lifecycle_context,
+    log_lifecycle_event,
 )
 
 logger = structlog.get_logger(__name__)
@@ -87,6 +89,7 @@ class WebhookHandler:
             return await self._handle_pull_request_event(
                 payload,
                 delivery,
+                source=work_event.source,
                 workflow_id=workflow_id,
             )
 
@@ -314,6 +317,7 @@ class WebhookHandler:
         payload: dict[str, Any],
         delivery: str | None,
         *,
+        source: str = "github",
         workflow_id: str | None,
     ) -> dict[str, Any]:
         action = (payload.get("action") or "").strip()
@@ -325,34 +329,46 @@ class WebhookHandler:
         if pr is None:
             raise ValueError("❌ ERROR: pull_request payload missing metadata")
 
+        resolved_workflow_id = workflow_id or _generate_workflow_id()
+        pr_event_context = build_lifecycle_context(
+            event="pull_request",
+            payload=payload,
+            delivery=delivery,
+            source=source,
+            workflow_id=resolved_workflow_id,
+            default_project=self._default_project_name(),
+            issue_key=f"{pr.repo_owner}/{pr.repo_name}#{pr.number}",
+            action=action,
+        )
+
         if not self._pr_review_enabled():
-            logger.info(
-                "webhook_lifecycle",
+            log_lifecycle_event(
+                logger,
                 stage=STAGE_PR_REVIEW_SKIPPED,
+                context=pr_event_context,
                 reason="pr_review_disabled",
-                action="pr_review",
                 pr_number=pr.number,
                 repo=f"{pr.repo_owner}/{pr.repo_name}",
             )
             return {"status": "ignored", "reason": "pr_review_disabled"}
 
         if not self._is_pull_request_repo_allowed(pr.repo_owner, pr.repo_name):
-            logger.info(
-                "webhook_lifecycle",
+            log_lifecycle_event(
+                logger,
                 stage=STAGE_PR_REVIEW_SKIPPED,
+                context=pr_event_context,
                 reason="repo_not_allowed",
-                action="pr_review",
                 pr_number=pr.number,
                 repo=f"{pr.repo_owner}/{pr.repo_name}",
             )
             return {"status": "ignored", "reason": "repo_not_allowed"}
 
         if pr.is_draft:
-            logger.info(
-                "webhook_lifecycle",
+            log_lifecycle_event(
+                logger,
                 stage=STAGE_PR_REVIEW_SKIPPED,
+                context=pr_event_context,
                 reason="draft_pr",
-                action="pr_review",
                 pr_number=pr.number,
                 repo=f"{pr.repo_owner}/{pr.repo_name}",
             )
@@ -362,15 +378,13 @@ class WebhookHandler:
             logger.info("webhook_ignored", event="pull_request", reason="action_not_reviewable")
             return {"status": "ignored", "reason": "action_not_reviewable"}
 
-        resolved_workflow_id = workflow_id or _generate_workflow_id()
-        logger.info(
-            "webhook_lifecycle",
+        log_lifecycle_event(
+            logger,
             stage=STAGE_PR_REVIEW_STARTED,
-            action=action,
+            context=pr_event_context,
             pr_number=pr.number,
             repo=f"{pr.repo_owner}/{pr.repo_name}",
             workflow_id=resolved_workflow_id,
-            delivery_id=delivery,
         )
 
         store = self._get_pr_review_store()
@@ -399,11 +413,11 @@ class WebhookHandler:
         claim = await store.claim_job(record)
         if not claim.claimed:
             if claim.reason == "review_in_progress":
-                logger.info(
-                    "webhook_lifecycle",
+                log_lifecycle_event(
+                    logger,
                     stage=STAGE_PR_REVIEW_SKIPPED,
+                    context=pr_event_context,
                     reason=claim.reason,
-                    action="pr_review",
                     pr_number=pr.number,
                     repo=f"{pr.repo_owner}/{pr.repo_name}",
                     head_sha=pr.head_sha,
@@ -443,10 +457,10 @@ class WebhookHandler:
                 pubsub_message_id=message_id,
                 queued_at=queued_at,
             )
-            logger.info(
-                "webhook_lifecycle",
+            log_lifecycle_event(
+                logger,
                 stage=STAGE_PR_REVIEW_ENQUEUED,
-                action="pr_review",
+                context=pr_event_context,
                 pubsub_message_id=message_id,
                 pr_number=pr.number,
                 repo=f"{pr.repo_owner}/{pr.repo_name}",
@@ -463,10 +477,10 @@ class WebhookHandler:
                 "message_id": message_id,
             }
         except Exception as exc:
-            logger.info(
-                "webhook_lifecycle",
+            log_lifecycle_event(
+                logger,
                 stage=STAGE_PR_REVIEW_ERROR,
-                action="pr_review",
+                context=pr_event_context,
                 reason="pr_review_publish_failed",
                 error=str(exc),
                 pr_number=pr.number,

--- a/src/ace/webhooks/lifecycle.py
+++ b/src/ace/webhooks/lifecycle.py
@@ -33,7 +33,15 @@ STAGE_PR_REVIEW_CONSENSUS = "pr_review_consensus"
 STAGE_PR_REVIEW_APPROVAL_SUBMITTED = "pr_review_approval_submitted"
 STAGE_PR_REVIEW_MERGED = "pr_review_merged"
 STAGE_PR_REVIEW_REJECTED = "pr_review_rejected"
+STAGE_PR_REVIEW_ENQUEUED = "pr_review_enqueued"
+STAGE_PR_REVIEW_SKIPPED = "pr_review_skipped"
 STAGE_PR_REVIEW_ERROR = "pr_review_error"
+
+STAGE_SESSION_START = "session_start"
+STAGE_SESSION_TURN_START = "session_turn_start"
+STAGE_SESSION_TURN_COMPLETE = "session_turn_complete"
+STAGE_SESSION_STALL = "session_stall"
+STAGE_SESSION_RESUME = "session_resume"
 
 RESOLUTION_SUCCESS = "success"
 RESOLUTION_BLOCKED = "blocked"
@@ -51,6 +59,7 @@ class WebhookLifecycleContext:
     target_gcp_project: str | None
     delivery_id: str | None
     workflow_id: str
+    source: str
 
 
 @dataclass(frozen=True)
@@ -64,6 +73,27 @@ class PlanningLifecycleContext:
     request_id: str | None
 
 
+@dataclass(frozen=True)
+class SessionLifecycleContext:
+    """Structured context for session-based runtime telemetry."""
+
+    source: str
+    issue_key: str | None
+    session_id: str
+    turn_number: int
+    workflow_id: str
+    project: str | None = None
+    target_gcp_project: str | None = None
+    action: str | None = None
+    stage_total: int | None = None
+    stage_index: int | None = None
+
+
+def _normalize_source(source: str | None) -> str:
+    normalized = (source or "").strip().lower()
+    return normalized or "github"
+
+
 def build_lifecycle_context(
     *,
     event: str,
@@ -74,6 +104,7 @@ def build_lifecycle_context(
     project: str | None = None,
     issue_key: str | None = None,
     target_gcp_project: str | None = None,
+    source: str | None = None,
     repo_gcp_mapping: Mapping[str, str] | None = None,
     action: str | None = None,
 ) -> WebhookLifecycleContext:
@@ -118,6 +149,50 @@ def build_lifecycle_context(
         target_gcp_project=resolved_target_gcp_project,
         delivery_id=normalized_delivery,
         workflow_id=resolved_workflow_id,
+        source=_normalize_source(source),
+    )
+
+
+def build_session_lifecycle_context(
+    *,
+    session_id: str,
+    turn_number: int,
+    workflow_id: str,
+    source: str | None = None,
+    issue_key: str | None = None,
+    project: str | None = None,
+    target_gcp_project: str | None = None,
+    action: str | None = None,
+    stage_total: int | None = None,
+    stage_index: int | None = None,
+) -> SessionLifecycleContext:
+    """Build a normalized session context for runtime lifecycle telemetry."""
+    session_value = (session_id or "").strip()
+    if not session_value:
+        raise ValueError("❌ ERROR: session_id is required for session telemetry")
+
+    if not isinstance(turn_number, int) or turn_number < 1:
+        raise ValueError(
+            "❌ ERROR: turn_number is required for session telemetry and must be > 0"
+        )
+
+    workflow_value = (workflow_id or "").strip()
+    if not workflow_value:
+        raise ValueError("❌ ERROR: workflow_id is required for session telemetry")
+
+    issue_value = issue_key.strip() if isinstance(issue_key, str) and issue_key.strip() else None
+
+    return SessionLifecycleContext(
+        source=_normalize_source(source),
+        issue_key=issue_value,
+        session_id=session_value,
+        turn_number=turn_number,
+        workflow_id=workflow_value,
+        project=project,
+        target_gcp_project=target_gcp_project,
+        action=action,
+        stage_total=stage_total,
+        stage_index=stage_index,
     )
 
 
@@ -192,6 +267,7 @@ def log_lifecycle_event(
 ) -> None:
     """Emit a structured lifecycle log entry with canonical correlation fields."""
     bound_logger = logger.bind(
+        source=context.source,
         event=context.event,
         action=context.action,
         project=context.project,
@@ -205,6 +281,35 @@ def log_lifecycle_event(
         data["resolution"] = resolution
     data.update(fields)
     bound_logger.info("webhook_lifecycle", **data)
+
+
+def log_session_lifecycle_event(
+    logger: structlog.BoundLogger,
+    stage: str,
+    context: SessionLifecycleContext,
+    *,
+    resolution: str | None = None,
+    **fields: Any,
+) -> None:
+    """Emit a structured session lifecycle event."""
+    bound_logger = logger.bind(
+        source=context.source,
+        workflow_id=context.workflow_id,
+        issue_key=context.issue_key,
+        project=context.project,
+        target_gcp_project=context.target_gcp_project,
+        session_id=context.session_id,
+        turn_number=context.turn_number,
+        action=context.action,
+        stage_total=context.stage_total,
+        stage_index=context.stage_index,
+    )
+
+    data = {"stage": stage}
+    if resolution is not None:
+        data["resolution"] = resolution
+    data.update(fields)
+    bound_logger.info("session_lifecycle", **data)
 
 
 def normalize_result_resolution(result: dict[str, Any]) -> str:

--- a/src/ace/webhooks/pubsub_queue.py
+++ b/src/ace/webhooks/pubsub_queue.py
@@ -18,6 +18,7 @@ class QueuedWebhookEvent:
     event: str
     payload: dict[str, Any]
     delivery: str | None
+    source: str = "github"
     workflow_id: str | None = None
     issue_key: str | None = None
     project: str | None = None
@@ -53,6 +54,7 @@ class PubSubWebhookQueue:
         event: str,
         payload: dict[str, Any],
         delivery: str | None,
+        source: str = "github",
         workflow_id: str | None = None,
         issue_key: str | None = None,
         project: str | None = None,
@@ -62,6 +64,7 @@ class PubSubWebhookQueue:
     ) -> str:
         correlation = {
             "delivery_id": delivery,
+            "source": source,
             "workflow_id": workflow_id,
             "issue_key": issue_key,
             "project": project,
@@ -73,6 +76,7 @@ class PubSubWebhookQueue:
             "event": event,
             "payload": payload,
             "delivery": delivery,
+            "source": source,
             "workflow_id": workflow_id,
             "queued_at": queued_at,
             "correlation": correlation,
@@ -88,6 +92,8 @@ class PubSubWebhookQueue:
             attrs["issue_key"] = issue_key
         if project:
             attrs["project"] = project
+        if source:
+            attrs["source"] = source
         if target_gcp_project:
             attrs["target_gcp_project"] = target_gcp_project
         if action:
@@ -137,6 +143,14 @@ def decode_pubsub_push(body: dict[str, Any]) -> QueuedWebhookEvent:
     if not isinstance(correlation, dict):
         raise ValueError("❌ ERROR: invalid_pubsub_push: correlation must be an object")
 
+    source = _first_string(
+        envelope.get("source"),
+        correlation.get("source"),
+        attrs.get("source"),
+    )
+    if source is None:
+        source = "github"
+
     delivery = _first_string(
         envelope.get("delivery"),
         correlation.get("delivery_id"),
@@ -182,6 +196,7 @@ def decode_pubsub_push(body: dict[str, Any]) -> QueuedWebhookEvent:
         event=event,
         payload=payload,
         delivery=delivery,
+        source=source,
         workflow_id=workflow_id,
         issue_key=issue_key,
         project=project,

--- a/tests/test_graph_session_runtime_integration.py
+++ b/tests/test_graph_session_runtime_integration.py
@@ -13,6 +13,22 @@ from ace.orchestration.session_runtime import SessionTurnType
 from ace.orchestration.state import WorkerState
 
 
+class _BoundLogger:
+    def __init__(self, events: list[dict[str, object]]) -> None:
+        self._events = events
+        self._bound = {}
+
+    def bind(self, **kwargs):
+        child = _BoundLogger(self._events)
+        child._bound = {**self._bound, **kwargs}
+        return child
+
+    def info(self, event_name: str, **fields: object) -> None:
+        merged = {**self._bound}
+        merged.update(fields)
+        self._events.append({"event_name": event_name, "fields": merged})
+
+
 def _build_issue() -> SimpleNamespace:
     return SimpleNamespace(
         number=123,
@@ -213,3 +229,112 @@ async def test_run_agent_uses_retry_turn_type_for_restarts(
     _, _, previous_result = captured_runner.run_calls[0]
     assert previous_result is not None
     assert previous_result.error == "Need to continue from prior output."
+
+
+@pytest.mark.asyncio
+async def test_run_agent_emits_session_lifecycle_events(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_builder = _BuilderProbe()
+    captured_runner = _RunnerProbe(backend="codex")
+
+    events: list[dict[str, object]] = []
+    logger = _BoundLogger(events)
+    old_logger = graph.logger
+    graph.logger = logger
+
+    def _build_runner(backend: str, model: str | None = None) -> _RunnerProbe:
+        captured_runner.backend = backend
+        captured_runner.model = model
+        return captured_runner
+
+    try:
+        monkeypatch.setattr(graph, "GitOps", _DummyGitOps)
+        monkeypatch.setattr(graph, "get_settings", lambda: _TrackingSettings(str(tmp_path)))
+        monkeypatch.setattr(graph, "resolve_github_token", lambda _settings: "token")
+        monkeypatch.setattr(graph, "SessionInstructionBuilder", lambda: captured_builder)
+        monkeypatch.setattr(graph, "build_session_runner", _build_runner)
+
+        state = WorkerState(issue=_build_issue(), issue_number=123, agent_id="agent-1")
+        state.metadata["repo_owner"] = "acme"
+        state.metadata["repo_name"] = "widget"
+        state.metadata["source"] = "github"
+
+        result_state = await graph.run_agent(state)
+
+        assert result_state.agent_result is not None
+        session_events = [
+            event for event in events if event["event_name"] == "session_lifecycle"
+        ]
+        stages = [event["fields"]["stage"] for event in session_events]
+        assert stages[:3] == [
+            "session_start",
+            "session_turn_start",
+            "session_turn_complete",
+        ]
+        first = session_events[0]["fields"]
+        assert first["source"] == "github"
+        assert first["issue_key"] == "acme/widget#123"
+        assert first["turn_number"] == 1
+    finally:
+        graph.logger = old_logger
+
+
+@pytest.mark.asyncio
+async def test_run_agent_emits_session_resume_and_stall(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_builder = _BuilderProbe()
+    captured_runner = _RunnerProbe(backend="codex")
+    captured_runner.request_input_result = True
+
+    events: list[dict[str, object]] = []
+    logger = _BoundLogger(events)
+    old_logger = graph.logger
+    graph.logger = logger
+
+    def _build_runner(backend: str, model: str | None = None) -> _RunnerProbe:
+        captured_runner.backend = backend
+        captured_runner.model = model
+        return captured_runner
+
+    try:
+        monkeypatch.setattr(graph, "GitOps", _DummyGitOps)
+        monkeypatch.setattr(graph, "get_settings", lambda: _TrackingSettings(str(tmp_path)))
+        monkeypatch.setattr(graph, "resolve_github_token", lambda _settings: "token")
+        monkeypatch.setattr(graph, "SessionInstructionBuilder", lambda: captured_builder)
+        monkeypatch.setattr(graph, "build_session_runner", _build_runner)
+
+        state = WorkerState(
+            issue=_build_issue(),
+            issue_number=123,
+            agent_id="agent-1",
+            session_turn=2,
+            retry_count=1,
+            previous_output="Need to continue from prior output.",
+        )
+        state.metadata["repo_owner"] = "acme"
+        state.metadata["repo_name"] = "widget"
+        state.metadata["source"] = "linear"
+
+        result_state = await graph.run_agent(state)
+
+        assert result_state.agent_result is not None
+        assert result_state.agent_result.status == AgentStatus.FAILED
+        session_events = [
+            event for event in events if event["event_name"] == "session_lifecycle"
+        ]
+        stages = [event["fields"]["stage"] for event in session_events]
+        assert stages[:4] == [
+            "session_start",
+            "session_resume",
+            "session_turn_start",
+            "session_stall",
+        ]
+        assert stages[-1] == "session_turn_complete"
+        assert session_events[1]["fields"]["reason"] == "previous_output_detected"
+        assert session_events[-1]["fields"]["requested_input"] is True
+    finally:
+        graph.logger = old_logger

--- a/tests/test_pubsub_queue.py
+++ b/tests/test_pubsub_queue.py
@@ -41,6 +41,7 @@ async def test_publish_includes_correlation_payload_and_attributes():
         target_gcp_project="widget-prod-123456",
         action="created",
         queued_at="2026-02-12T18:00:00+00:00",
+        source="linear",
     )
 
     assert message_id == "pubsub-123"
@@ -52,6 +53,7 @@ async def test_publish_includes_correlation_payload_and_attributes():
     assert call["attrs"]["project"] == "Acme Platform"
     assert call["attrs"]["target_gcp_project"] == "widget-prod-123456"
     assert call["attrs"]["queued_at"] == "2026-02-12T18:00:00+00:00"
+    assert call["attrs"]["source"] == "linear"
 
     envelope = json.loads(call["body"].decode("utf-8"))
     assert envelope["schema_version"] == "2"
@@ -62,6 +64,7 @@ async def test_publish_includes_correlation_payload_and_attributes():
     assert envelope["correlation"]["project"] == "Acme Platform"
     assert envelope["correlation"]["target_gcp_project"] == "widget-prod-123456"
     assert envelope["correlation"]["action"] == "created"
+    assert envelope["source"] == "linear"
 
 
 def test_decode_pubsub_push_reads_correlation_fields():
@@ -89,6 +92,7 @@ def test_decode_pubsub_push_reads_correlation_fields():
                 "project": "Acme Platform",
                 "target_gcp_project": "widget-prod-123456",
                 "queued_at": "2026-02-12T18:00:00+00:00",
+                "source": "linear",
             },
         }
     }
@@ -100,6 +104,7 @@ def test_decode_pubsub_push_reads_correlation_fields():
     assert queued.issue_key == "Acme-Corp/widget-api#99"
     assert queued.project == "Acme Platform"
     assert queued.target_gcp_project == "widget-prod-123456"
+    assert queued.source == "linear"
     assert queued.action == "edited"
     assert queued.queued_at == "2026-02-12T18:00:00+00:00"
 

--- a/tests/test_webhook_lifecycle.py
+++ b/tests/test_webhook_lifecycle.py
@@ -7,6 +7,9 @@ from ace.webhooks.lifecycle import (
     RESOLUTION_SUCCESS,
     RESOLUTION_TIMEOUT,
     build_lifecycle_context,
+    build_session_lifecycle_context,
+    log_session_lifecycle_event,
+    STAGE_SESSION_START,
     normalize_error_resolution,
     normalize_result_resolution,
 )
@@ -61,6 +64,16 @@ def test_build_lifecycle_context_uses_explicit_correlation_overrides():
     assert context.action == "edited"
 
 
+def test_build_lifecycle_context_normalizes_source():
+    context = build_lifecycle_context(
+        event="issue_comment",
+        payload={},
+        delivery="delivery-1",
+        source="LINEAR",
+    )
+    assert context.source == "linear"
+
+
 def test_build_lifecycle_context_fails_for_unmapped_repo():
     with pytest.raises(ValueError, match="❌ ERROR: repo_gcp_project_mapping_missing"):
         build_lifecycle_context(
@@ -75,6 +88,64 @@ def test_build_lifecycle_context_fails_for_unmapped_repo():
             delivery="delivery-123",
             repo_gcp_mapping={"acme-corp/widget-api": "widget-prod-123456"},
         )
+
+
+def test_build_session_lifecycle_context_requires_turn_number_and_workflow():
+    with pytest.raises(ValueError, match="turn_number"):
+        build_session_lifecycle_context(
+            session_id="run-123",
+            turn_number=0,
+            workflow_id="wf-1",
+            source="github",
+            issue_key="acme/widget#123",
+        )
+    with pytest.raises(ValueError, match="workflow_id"):
+        build_session_lifecycle_context(
+            session_id="run-123",
+            turn_number=1,
+            workflow_id="",
+            source="github",
+            issue_key="acme/widget#123",
+        )
+
+
+def test_build_session_lifecycle_context_normalizes_source_and_emits_fields():
+    context = build_session_lifecycle_context(
+        session_id="run-123",
+        turn_number=1,
+        workflow_id="wf-1",
+        source="LINEAR",
+        issue_key="acme/widget#123",
+    )
+    assert context.source == "linear"
+
+    events: list[dict[str, object]] = []
+
+    class _BoundLogger:
+        def __init__(self) -> None:
+            self._events = events
+            self._bound = {}
+
+        def bind(self, **kwargs):
+            child = _BoundLogger()
+            child._events = self._events
+            child._bound = {**self._bound, **kwargs}
+            return child
+
+        def info(self, event_name: str, **fields: object) -> None:
+            merged = {**self._bound}
+            merged.update(fields)
+            self._events.append({"event_name": event_name, "fields": merged})
+
+    logger = _BoundLogger()
+    log_session_lifecycle_event(logger, STAGE_SESSION_START, context)
+    assert events and events[0]["event_name"] == "session_lifecycle"
+    fields = events[0]["fields"]
+    assert fields["source"] == "linear"
+    assert fields["session_id"] == "run-123"
+    assert fields["turn_number"] == 1
+    assert fields["issue_key"] == "acme/widget#123"
+    assert fields["stage"] == STAGE_SESSION_START
 
 
 def test_normalize_result_resolution():


### PR DESCRIPTION
Implements Issues #30 and #31.

- Adds source-aware webhook lifecycle context and propagates source through listener queue/push path.
- Completes PR-review lifecycle constants and canonical logging usage.
- Adds session lifecycle telemetry for worker runtime (start, turn_start, turn_complete, stall, resume).
- Adds tests for structured event emission and pubsub source correlation.

Closes #30
Closes #31